### PR TITLE
[codex] fix project validation gates

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,W503

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,40 @@
+name: Check Formatting
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: latest
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v3
+      with:
+        path: .venv
+        key: format-venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Install formatter
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry install --no-interaction --no-root --only dev
+
+    - name: Check formatting
+      run: poetry run black --check sandwich_numerical tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,45 +9,54 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         python-version: ["3.11"]
-    
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
         version: latest
         virtualenvs-create: true
         virtualenvs-in-project: true
-    
+
     - name: Load cached venv
       id: cached-poetry-dependencies
       uses: actions/cache@v3
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
-    
+
     - name: Install dependencies
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --no-root
-    
+
     - name: Install project
       run: poetry install --only-root
-    
+
+    - name: Check formatting
+      run: poetry run black --check sandwich_numerical tests
+
+    - name: Lint
+      run: poetry run flake8 sandwich_numerical tests
+
+    - name: Type check
+      run: poetry run mypy sandwich_numerical
+
     - name: Run tests with coverage
       run: poetry run pytest tests/ --cov=sandwich_numerical --cov-report=xml --cov-report=term-missing
-    
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
-        fail_ci_if_error: false 
+        fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ import numpy as np
 
 # Create a gradient vector
 block_size = (10, 10)  # (height, width)
-grad_vec = np.linspace(0, 1, 3 * block_size[0] + 1)
+grad_vec = np.linspace(0, 1, 3 * block_size[0])
 
 # Create and use the Sandwich solver
 mesh = Sandwich(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,6 @@ myst-parser = "^1.0.0"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry.scripts]
-sandwich-demo = "sandwich_numerical.main:main"
-
 [tool.black]
 line-length = 88
 target-version = ['py311']
@@ -52,9 +49,13 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 
+[[tool.mypy.overrides]]
+module = ["plotly.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "--cov=sandwich_numerical --cov-report=html --cov-report=term-missing" 
+addopts = "--cov=sandwich_numerical --cov-report=html --cov-report=term-missing"

--- a/sandwich_numerical/__init__.py
+++ b/sandwich_numerical/__init__.py
@@ -1,1 +1,1 @@
-
+"""Sandwich numerical analysis package."""

--- a/sandwich_numerical/sandwich.py
+++ b/sandwich_numerical/sandwich.py
@@ -1,100 +1,120 @@
 import numpy as np
 import plotly.graph_objects as go
 from sandwich_numerical.solver.mesh_block import BoundaryType, MeshBlock
-from sandwich_numerical.solver.mesh_utils import copy_boundary_gradients, copy_boundary_values
+from sandwich_numerical.solver.mesh_utils import (
+    copy_boundary_gradients,
+    copy_boundary_values,
+)
 
 from .solver.laplace import set_laplace_update
 
 
-def set_boundary_conditions_bottom_block(state: MeshBlock, 
-                                       grad_vec: np.ndarray, grid_step: float):
+def set_boundary_conditions_bottom_block(
+    state: MeshBlock, grad_vec: np.ndarray, grid_step: float
+) -> None:
     """
     Set boundary conditions for the bottom block of the sandwich structure.
-    
+
     This function enforces three types of boundary conditions:
     1. Fixed boundary: The far end (right side) is clamped to zero
     2. Zero gradient: The bottom side has zero normal derivative (df/dx2 = 0)
-    3. Prescribed gradient: The near end (left side) has a known gradient from grad_vec
-    
+    3. Prescribed gradient: The near end (left side) has a known gradient
+       from grad_vec
+
     Args:
         state (MeshBlock): Current state mesh block
-        grad_vec (np.ndarray): Gradient vector specifying the prescribed gradient at the near end
+        grad_vec (np.ndarray): Gradient vector specifying the prescribed gradient
+            at the near end
         grid_step (float): Grid spacing for finite difference calculations
-        
+
     Note:
         The function modifies state in-place by setting boundary values.
     """
 
-    state.set_boundary_values(BoundaryType.RIGHT, 0) # the block is fixed on the far end
-    state.set_boundary_gradients(BoundaryType.BOTTOM, 0) # df/dx2 = 0 on the bottom side
-    
+    state.set_boundary_values(
+        BoundaryType.RIGHT, 0
+    )  # the block is fixed on the far end
+    state.set_boundary_gradients(BoundaryType.BOTTOM, 0)  # df/dx2 = 0
+
     # gradients are known on the near end
     state.set_boundary_gradients(BoundaryType.LEFT, grad_vec * grid_step)
 
 
-def set_boundary_conditions_top_block(state: MeshBlock, 
-                                    grad_vec: np.ndarray, grid_step: float):
+def set_boundary_conditions_top_block(
+    state: MeshBlock, grad_vec: np.ndarray, grid_step: float
+) -> None:
     """
     Set boundary conditions for the top block of the sandwich structure.
-    
+
     This function enforces three types of boundary conditions:
     1. Fixed boundary: The far end (right side) is clamped to zero
     2. Zero gradient: The top side has zero normal derivative (df/dx2 = 0)
-    3. Prescribed gradient: The near end (left side) has a known gradient from grad_vec
-    
+    3. Prescribed gradient: The near end (left side) has a known gradient
+       from grad_vec
+
     Args:
         state (MeshBlock): Current state mesh block
-        grad_vec (np.ndarray): Gradient vector specifying the prescribed gradient at the near end
+        grad_vec (np.ndarray): Gradient vector specifying the prescribed gradient
+            at the near end
         grid_step (float): Grid spacing for finite difference calculations
-        
+
     Note:
         The function modifies state in-place by setting boundary values.
     """
-    
-    state.set_boundary_values(BoundaryType.RIGHT, 0) # the block is fixed on the far end
-    state.set_boundary_gradients(BoundaryType.TOP, 0) # df/dx2 = 0 on the top side
-    
+
+    state.set_boundary_values(
+        BoundaryType.RIGHT, 0
+    )  # the block is fixed on the far end
+    state.set_boundary_gradients(BoundaryType.TOP, 0)  # df/dx2 = 0
+
     # gradients are known on the near end
     state.set_boundary_gradients(BoundaryType.LEFT, grad_vec * grid_step)
 
 
-def set_boundary_conditions_middle_block(state: MeshBlock,
-                                       grad_vec: np.ndarray, grid_step: float):
+def set_boundary_conditions_middle_block(
+    state: MeshBlock, grad_vec: np.ndarray, grid_step: float
+) -> None:
     """
     Set boundary conditions for the middle block of the sandwich structure.
-    
+
     This function enforces two types of boundary conditions:
     1. Fixed boundary: The far end (right side) is clamped to zero
-    2. Prescribed gradient: The near end (left side) has a known gradient from grad_vec
-    
+    2. Prescribed gradient: The near end (left side) has a known gradient
+       from grad_vec
+
     Args:
         state (MeshBlock): Current state mesh block
-        grad_vec (np.ndarray): Gradient vector specifying the prescribed gradient at the near end
+        grad_vec (np.ndarray): Gradient vector specifying the prescribed gradient
+            at the near end
         grid_step (float): Grid spacing for finite difference calculations
-        
+
     Note:
         The function modifies next_state in-place by setting boundary values.
         The middle block has no zero-gradient conditions on top/bottom sides.
     """
 
-    state.set_boundary_values(BoundaryType.RIGHT, 0) # the block is fixed on the far end
-    
+    state.set_boundary_values(
+        BoundaryType.RIGHT, 0
+    )  # the block is fixed on the far end
+
     # gradients are known on the near end
     state.set_boundary_gradients(BoundaryType.LEFT, grad_vec * grid_step)
 
 
 class Sandwich:
     """
-    A multi-block numerical solver implementing the Sandwich method for differential equations.
-    
-    The Sandwich method divides the computational domain into three blocks (bottom, middle, top)
-    and solves them iteratively with data transfer between blocks. This approach allows for
-    efficient solution of large-scale problems by breaking them into manageable sub-problems
-    while maintaining solution continuity across block boundaries.
-    
+    A multi-block numerical solver implementing the Sandwich method.
+
+    The Sandwich method divides the computational domain into three blocks
+    (bottom, middle, top) and solves them iteratively with data transfer between
+    blocks. This approach allows for efficient solution of large-scale problems
+    by breaking them into manageable sub-problems while maintaining solution
+    continuity across block boundaries.
+
     The solver uses finite difference methods with the Laplace operator and implements
-    various boundary conditions including fixed boundaries, zero gradients, and prescribed gradients.
-    
+    various boundary conditions including fixed boundaries, zero gradients, and
+    prescribed gradients.
+
     Attributes:
         block_size (tuple): Size of each block as (height, width)
         grad_vec (np.ndarray): Vector of prescribed gradients at block boundaries
@@ -104,42 +124,93 @@ class Sandwich:
         curr_state_* (np.ndarray): Current state arrays for each block
         next_state_* (np.ndarray): Next state arrays for each block (working arrays)
     """
-    
-    def __init__(self, block_size, grad_vec, grid_step, grad_factor):
+
+    def __init__(
+        self,
+        block_size: tuple[int, int],
+        grad_vec: np.ndarray,
+        grid_step: float,
+        grad_factor: float,
+    ) -> None:
         """
         Initialize the Sandwich solver with the specified parameters.
-        
+
         Args:
             block_size (tuple): Size of each block as (height, width)
             grad_vec (np.ndarray): Vector of prescribed gradients at block boundaries.
-                                  Must have length 3*block_height + 1 for proper indexing.
+                                  Must have length 3*block_height.
             grid_step (float): Grid spacing for finite difference calculations
             grad_factor (float): Factor for scaling gradients in the middle block.
-                               Values > 1 increase middle block gradients, < 1 decrease them.
-        
+                               Values > 1 increase middle block gradients,
+                               < 1 decrease them.
+
         Note:
-            The middle block is created with 2 extra rows (top and bottom) to accommodate
-            boundary conditions and data transfer requirements.
+            The middle block is created with 2 extra rows (top and bottom) to
+            accommodate boundary conditions and data transfer requirements.
         """
-        self.block_size = block_size
-        self.grad_vec = grad_vec
-        self.grid_step = grid_step
-        self.grad_factor = grad_factor
-        
-        self.block_height = block_size[0]
+        self.block_size = self._validate_block_size(block_size)
+        self.block_height = self.block_size[0]
+        self.grad_vec = self._validate_grad_vec(grad_vec, self.block_height)
+        self.grid_step = self._validate_positive_number(grid_step, "grid_step")
+        self.grad_factor = self._validate_positive_number(grad_factor, "grad_factor")
 
         # Current state blocks
-        self.top = MeshBlock(block_size)
-        self.bottom = MeshBlock(block_size)
-        
+        self.top = MeshBlock(self.block_size)
+        self.bottom = MeshBlock(self.block_size)
+
         # we need one more row from each side because of boundary conditions
-        mid_block_size = (block_size[0] + 2, block_size[1])
+        mid_block_size = (self.block_size[0] + 2, self.block_size[1])
         self.mid = MeshBlock(mid_block_size)
-        
-    def step(self):
+
+    @staticmethod
+    def _validate_block_size(block_size: tuple[int, int]) -> tuple[int, int]:
+        if not isinstance(block_size, tuple):
+            raise TypeError("block_size must be a tuple (height, width)")
+
+        if len(block_size) != 2:
+            raise ValueError("block_size must be 2-dimensional (height, width)")
+
+        height, width = block_size
+        if not isinstance(height, int) or not isinstance(width, int):
+            raise TypeError("block_size values must be integers")
+
+        if height < 2 or width < 2:
+            raise ValueError("block_size values must be at least 2")
+
+        return block_size
+
+    @staticmethod
+    def _validate_grad_vec(grad_vec: np.ndarray, block_height: int) -> np.ndarray:
+        grad_array = np.asarray(grad_vec, dtype=float)
+        expected_length = 3 * block_height
+
+        if grad_array.ndim != 1:
+            raise ValueError("grad_vec must be a 1-dimensional array")
+
+        if grad_array.shape != (expected_length,):
+            raise ValueError(
+                "grad_vec must have shape "
+                f"({expected_length},), got {grad_array.shape}"
+            )
+
+        return grad_array
+
+    @staticmethod
+    def _validate_positive_number(value: float, name: str) -> float:
+        numeric_value = float(value)
+
+        if not np.isfinite(numeric_value):
+            raise ValueError(f"{name} must be finite")
+
+        if numeric_value <= 0:
+            raise ValueError(f"{name} must be positive")
+
+        return numeric_value
+
+    def step(self) -> None:
         """
         Execute one complete iteration step of the Sandwich solver.
-        
+
         This method performs the complete solution cycle:
         1. Set boundary conditions for all blocks
         2. Apply Laplace operator to outer blocks (bottom and top)
@@ -147,7 +218,7 @@ class Sandwich:
         4. Apply Laplace operator to middle block
         5. Transfer data from middle block back to outer blocks
         6. Swap current and next state arrays
-        
+
         Note:
             This method modifies the internal state arrays in-place.
             Call this method repeatedly in a loop to converge to the solution.
@@ -157,139 +228,140 @@ class Sandwich:
         self._transfer_values_inwards()
         self._make_laplace_step_inner()
         self._transfer_gradients_outwards()
-        
-    def plot(self, plot_abs=False):
+
+    def plot(self, plot_abs: bool = False) -> go.Figure:
         """
         Generate a heatmap visualization of the current displacement field.
-        
+
         Args:
-            plot_abs (bool, optional): If True, plot the absolute values of displacement.
-                                     If False (default), plot the raw displacement values.
-        
+            plot_abs (bool, optional): If True, plot absolute displacement values.
+                If False (default), plot raw displacement values.
+
         Returns:
             plotly.graph_objs._figure.Figure: A Plotly heatmap figure showing the
             displacement field across all three blocks.
-        
+
         Note:
             The displacement array is flipped vertically ([::-1]) to match conventional
             plotting conventions where the origin is at the bottom-left.
         """
         displacement = self.get_displacement_array()[::-1]
-        
+
         if plot_abs:
             displacement = np.abs(displacement)
-        
+
         return go.Figure(data=go.Heatmap(z=displacement))
-    
-    def get_displacement_array(self):
+
+    def get_displacement_array(self) -> np.ndarray:
         """
         Get the complete displacement field across all three blocks.
-        
+
         Returns:
             np.ndarray: A concatenated array containing the displacement values
                        from all three blocks in the order: bottom, middle, top.
                        The middle block excludes the boundary padding rows.
-        
+
         Note:
             The returned array has shape (3*block_height, block_width) and represents
             the current state of the entire computational domain.
         """
         return np.concatenate(
             (
-                self.bottom._state, 
-                self.mid._state[1:-1], # remove boundary conditions paddings 
-                self.top._state
+                self.bottom._state,
+                self.mid._state[1:-1],  # remove boundary conditions paddings
+                self.top._state,
             )
         )
-    
-    def get_residual(self):
+
+    def get_residual(self) -> float:
         """
         Calculate the residual (error) of the current solution.
-        
+
         The residual measures how well the current state satisfies the Laplace equation.
         It is computed as the sum of absolute differences between the current state
         and what the Laplace operator would predict for that state.
-        
+
         Returns:
             float: The total residual across all three blocks. Lower values indicate
                    better convergence to the solution.
-        
+
         Note:
             The residual is computed only for interior points (excluding boundaries)
             and summed across all blocks. This value can be used to monitor convergence
             during iterative solution.
         """
-        results = []
+        results: list[float] = []
         for block in [self.bottom._state, self.mid._state, self.top._state]:
             res_block = np.copy(block)
             set_laplace_update(res_block)
-            
+
             results.append(
-                np.sum(
-                    np.abs(
-                        block[1:-1, 1:-1] - res_block[1:-1, 1:-1]
-                    )
-                )
+                float(np.sum(np.abs(block[1:-1, 1:-1] - res_block[1:-1, 1:-1])))
             )
-            
+
         return sum(results)
-        
-    def _set_boundary_conditions(self):
+
+    def _set_boundary_conditions(self) -> None:
         """
         Set boundary conditions for all three blocks.
-        
+
         This private method applies the appropriate boundary conditions to each block:
         - Bottom block: Uses first block_height elements of grad_vec
-        - Middle block: Uses elements from block_height-1 to 2*block_height+1 of grad_vec
-        - Top block: Uses remaining elements of grad_vec
-        
+        - Middle block: Uses elements from block_height-1 to 2*block_height+1
+          of grad_vec
+        - Top block: Uses last block_height elements of grad_vec
+
         Note:
             This method modifies the next_state arrays in-place by calling the
             appropriate boundary condition functions for each block.
         """
         set_boundary_conditions_bottom_block(
-            self.bottom, 
-            self.grad_vec[:self.block_height], 
-            self.grid_step
+            self.bottom, self.grad_vec[: self.block_height], self.grid_step
         )
         set_boundary_conditions_middle_block(
-            self.mid, 
-            self.grad_vec[self.block_height-1:2*self.block_height+1], 
-            self.grid_step
+            self.mid,
+            self.grad_vec[self.block_height - 1 : 2 * self.block_height + 1],
+            self.grid_step,
         )
         set_boundary_conditions_top_block(
-            self.top, 
-            self.grad_vec[2*self.block_height:3*self.block_height], 
-            self.grid_step
+            self.top,
+            self.grad_vec[2 * self.block_height : 3 * self.block_height],
+            self.grid_step,
         )
-        
-    def _make_laplace_step_outer(self):
+
+    def _make_laplace_step_outer(self) -> None:
         """
         Apply Laplace operator to the outer blocks (bottom and top).
-        
+
         This private method updates the next_state arrays of the bottom and top blocks
         by applying the finite difference Laplace operator to their current states.
         """
         set_laplace_update(self.bottom._state)
         set_laplace_update(self.top._state)
-        
-    def _make_laplace_step_inner(self):
+
+    def _make_laplace_step_inner(self) -> None:
         """
         Apply Laplace operator to the middle block.
-        
+
         This private method updates the next_state array of the middle block
         by applying the finite difference Laplace operator to its current state.
         """
         set_laplace_update(self.mid._state)
 
-    def _transfer_values_inwards(self):
+    def _transfer_values_inwards(self) -> None:
         # displacements are continuous
-        copy_boundary_values(self.bottom, BoundaryType.TOP, self.mid, BoundaryType.BOTTOM)
+        copy_boundary_values(
+            self.bottom, BoundaryType.TOP, self.mid, BoundaryType.BOTTOM
+        )
         copy_boundary_values(self.top, BoundaryType.BOTTOM, self.mid, BoundaryType.TOP)
 
-    def _transfer_gradients_outwards(self):
+    def _transfer_gradients_outwards(self) -> None:
         # grads are proportional
         grad_scale = 1 / self.grad_factor
 
-        copy_boundary_gradients(self.mid, BoundaryType.BOTTOM, self.bottom, BoundaryType.TOP, grad_scale)
-        copy_boundary_gradients(self.mid, BoundaryType.TOP, self.top, BoundaryType.BOTTOM, grad_scale)
+        copy_boundary_gradients(
+            self.mid, BoundaryType.BOTTOM, self.bottom, BoundaryType.TOP, grad_scale
+        )
+        copy_boundary_gradients(
+            self.mid, BoundaryType.TOP, self.top, BoundaryType.BOTTOM, grad_scale
+        )

--- a/sandwich_numerical/solver/laplace.py
+++ b/sandwich_numerical/solver/laplace.py
@@ -1,28 +1,29 @@
 import numpy as np
 
 
-def set_laplace_update(state: np.ndarray):
+def set_laplace_update(state: np.ndarray) -> None:
     """
     Apply the Laplace operator to update the next state from the current state.
-    
+
     This function implements a finite difference approximation of the Laplace operator
     using a 5-point stencil. It computes the average of the four neighboring values
     (left, right, bottom, top) for each interior point.
-    
+
     Args:
         state (np.ndarray): Current state array of shape (n, m)
-        
+
     Note:
         The function updates only the interior points (1:-1, 1:-1) of state.
-        Boundary points are assumed to be handled separately by boundary condition functions.
+        Boundary points are assumed to be handled separately by boundary
+        condition functions.
     """
-    
+
     assert len(state.shape) == 2
-    
+
     values_left = state[1:-1, :-2]
     values_right = state[1:-1, 2:]
-    
+
     values_bottom = state[:-2, 1:-1]
     values_top = state[2:, 1:-1]
-    
-    state[1:-1, 1:-1] = (values_left + values_right + values_bottom + values_top) / 4 
+
+    state[1:-1, 1:-1] = (values_left + values_right + values_bottom + values_top) / 4

--- a/sandwich_numerical/solver/mesh_block.py
+++ b/sandwich_numerical/solver/mesh_block.py
@@ -1,10 +1,12 @@
 import numpy as np
-from typing import Union, Callable
+import numpy.typing as npt
+from typing import Union
 from enum import Enum
 
 
 class BoundaryType(Enum):
     """Enumeration of valid boundary types for the mesh block."""
+
     LEFT = "left"
     RIGHT = "right"
     TOP = "top"
@@ -14,136 +16,156 @@ class BoundaryType(Enum):
 class MeshBlock:
     """
     A class that stores a numpy array and provides methods for state management.
-    
+
     This class encapsulates a 2D numpy array representing a mesh block and provides
     a safe interface for updating the state in-place.
     """
-    
-    def __init__(self, shape: tuple, dtype: np.dtype = np.float64):
+
+    def __init__(self, shape: tuple, dtype: npt.DTypeLike = np.float64) -> None:
         """
         Initialize a MeshBlock with a numpy array of the specified shape.
-        
+
         Args:
             shape: Shape of the array as a tuple (height, width)
             dtype: Data type for the array (default: np.float64)
         """
         if not isinstance(shape, tuple):
             raise TypeError("Shape must be a tuple (height, width)")
-        
+
         if len(shape) != 2:
             raise ValueError("Shape must be 2-dimensional (height, width)")
-        
-        self._state = np.zeros(shape, dtype=dtype)
+
+        self._dtype = np.dtype(dtype)
+        self._state = np.zeros(shape, dtype=self._dtype)
         self._shape = shape
-        self._dtype = dtype
-    
+
     @property
     def state(self) -> np.ndarray:
         """
         Get the current state array.
-        
+
         Returns:
             The current state array (read-only view)
         """
         return self._state.view()
-    
+
     @property
     def shape(self) -> tuple:
         """
         Get the shape of the mesh block.
-        
+
         Returns:
             Tuple of (height, width)
         """
         return self._shape
-    
+
     @property
     def dtype(self) -> np.dtype:
         """
         Get the data type of the mesh block.
-        
+
         Returns:
             The numpy data type
         """
         return self._dtype
-    
+
     def set_state(self, new_state: np.ndarray) -> None:
         """
         Update the state array in-place with new values.
-        
+
         Args:
             new_state: New state array to copy into the current state
-            
+
         Raises:
             ValueError: If the new state has incompatible shape
         """
         if not isinstance(new_state, np.ndarray):
             raise TypeError("new_state must be a numpy array")
-        
+
         if new_state.shape != self._shape:
-            raise ValueError(f"Shape mismatch: expected {self._shape}, got {new_state.shape}")
-        
+            raise ValueError(
+                f"Shape mismatch: expected {self._shape}, got {new_state.shape}"
+            )
+
         # Copy the new state into the existing array (in-place update)
         # This will automatically handle dtype conversion if needed
         np.copyto(self._state, new_state)
-    
-    def set_boundary_values(self, boundary: BoundaryType, values: Union[np.ndarray, float, int]) -> None:
+
+    def set_boundary_values(
+        self, boundary: BoundaryType, values: Union[np.ndarray, float, int]
+    ) -> None:
         """
         Update boundary values of the mesh block.
-        
+
         Args:
             boundary: Boundary to update (must be BoundaryType enum)
             values: Values to set. Can be:
                 - Single number (float/int) to set all boundary points to the same value
                 - 1D numpy array with length matching the boundary dimension
                 - 2D numpy array with shape matching the boundary
-        
+
         Raises:
             ValueError: If values have incompatible shape
             TypeError: If boundary is not a BoundaryType enum
         """
         # Validate boundary type
         if not isinstance(boundary, BoundaryType):
-            raise TypeError(f"boundary must be a BoundaryType enum, got {type(boundary).__name__}")
-        
+            raise TypeError(
+                f"boundary must be a BoundaryType enum, got {type(boundary).__name__}"
+            )
+
         # Preprocess the values to ensure correct format
         preprocessed_values = self._preprocess_boundary_values(boundary, values)
-        
+
         # Validate and set boundary values
         if boundary == BoundaryType.LEFT:
             if preprocessed_values.shape != (self._shape[0],):
-                raise ValueError(f"Left boundary values must have shape ({self._shape[0]},), got {preprocessed_values.shape}")
+                raise ValueError(
+                    "Left boundary values must have shape "
+                    f"({self._shape[0]},), got {preprocessed_values.shape}"
+                )
             self._state[:, 0] = preprocessed_values
         elif boundary == BoundaryType.RIGHT:
             if preprocessed_values.shape != (self._shape[0],):
-                raise ValueError(f"Right boundary values must have shape ({self._shape[0]},), got {preprocessed_values.shape}")
+                raise ValueError(
+                    "Right boundary values must have shape "
+                    f"({self._shape[0]},), got {preprocessed_values.shape}"
+                )
             self._state[:, -1] = preprocessed_values
         elif boundary == BoundaryType.TOP:
             if preprocessed_values.shape != (self._shape[1],):
-                raise ValueError(f"Top boundary values must have shape ({self._shape[1]},), got {preprocessed_values.shape}")
+                raise ValueError(
+                    "Top boundary values must have shape "
+                    f"({self._shape[1]},), got {preprocessed_values.shape}"
+                )
             self._state[-1, :] = preprocessed_values
         elif boundary == BoundaryType.BOTTOM:
             if preprocessed_values.shape != (self._shape[1],):
-                raise ValueError(f"Bottom boundary values must have shape ({self._shape[1]},), got {preprocessed_values.shape}")
+                raise ValueError(
+                    "Bottom boundary values must have shape "
+                    f"({self._shape[1]},), got {preprocessed_values.shape}"
+                )
             self._state[0, :] = preprocessed_values
-    
+
     def get_boundary_values(self, boundary: BoundaryType) -> np.ndarray:
         """
         Get boundary values from the mesh block.
-        
+
         Args:
             boundary: Boundary to retrieve (must be BoundaryType enum)
-            
+
         Returns:
             Numpy array containing the boundary values
-            
+
         Raises:
             TypeError: If boundary is not a BoundaryType enum
         """
         # Validate boundary type
         if not isinstance(boundary, BoundaryType):
-            raise TypeError(f"boundary must be a BoundaryType enum, got {type(boundary).__name__}")
-        
+            raise TypeError(
+                f"boundary must be a BoundaryType enum, got {type(boundary).__name__}"
+            )
+
         # Return the appropriate boundary values
         if boundary == BoundaryType.LEFT:
             return self._state[:, 0].copy()
@@ -157,64 +179,68 @@ class MeshBlock:
             # This should never happen due to the enum validation above
             valid_boundaries = [b.value for b in BoundaryType]
             raise ValueError(f"Boundary must be one of: {valid_boundaries}")
-    
+
     def get_boundary_gradients(self, boundary: BoundaryType) -> np.ndarray:
         """
         Get boundary gradients from the mesh block.
-        
+
         The gradients are computed as:
         - Top gradient: "top line" - "adjacent line below"
         - Bottom gradient: "line adjacent to the bottom one" - "bottom line"
         - Left gradient: "line adjacent to the left line" - "left line"
         - Right gradient: "right line" - "line adjacent to the right line"
-        
+
         Args:
             boundary: Boundary to retrieve gradients for (must be BoundaryType enum)
-            
+
         Returns:
             Numpy array containing the boundary gradients
-            
+
         Raises:
             TypeError: If boundary is not a BoundaryType enum
             ValueError: If the mesh block is too small to compute gradients
         """
         # Validate boundary type
         if not isinstance(boundary, BoundaryType):
-            raise TypeError(f"boundary must be a BoundaryType enum, got {type(boundary).__name__}")
-        
+            raise TypeError(
+                f"boundary must be a BoundaryType enum, got {type(boundary).__name__}"
+            )
+
         # Check if the mesh block is large enough to compute gradients
         if self._shape[0] < 2 or self._shape[1] < 2:
             raise ValueError("Mesh block must be at least 2x2 to compute gradients")
-        
+
         # Compute gradients based on boundary type
         if boundary == BoundaryType.TOP:
             # Top gradient: top line - adjacent line below
-            return self._state[-1, :] - self._state[-2, :]
+            return np.asarray(self._state[-1, :] - self._state[-2, :])
         elif boundary == BoundaryType.BOTTOM:
             # Bottom gradient: line adjacent to bottom - bottom line
-            return self._state[1, :] - self._state[0, :]
+            return np.asarray(self._state[1, :] - self._state[0, :])
         elif boundary == BoundaryType.LEFT:
             # Left gradient: line adjacent to left - left line
-            return self._state[:, 1] - self._state[:, 0]
+            return np.asarray(self._state[:, 1] - self._state[:, 0])
         elif boundary == BoundaryType.RIGHT:
             # Right gradient: right line - line adjacent to right
-            return self._state[:, -1] - self._state[:, -2]
+            return np.asarray(self._state[:, -1] - self._state[:, -2])
         else:
             # This should never happen due to the enum validation above
             valid_boundaries = [b.value for b in BoundaryType]
             raise ValueError(f"Boundary must be one of: {valid_boundaries}")
-    
-    def _preprocess_boundary_values(self, boundary: BoundaryType, values: Union[np.ndarray, float, int]) -> np.ndarray:
+
+    def _preprocess_boundary_values(
+        self, boundary: BoundaryType, values: Union[np.ndarray, float, int]
+    ) -> np.ndarray:
         """
         Preprocess boundary values to ensure correct format and validate shape.
-        
+
         Args:
             boundary: Boundary type to determine expected shape
             values: Input values (can be number or numpy array)
-            
+
         Returns:
             Preprocessed numpy array with correct shape and dtype
-            
+
         Raises:
             TypeError: If values is not a number or numpy array
             ValueError: If values have incompatible shape
@@ -229,28 +255,36 @@ class MeshBlock:
             values_array = values
         else:
             raise TypeError("values must be a number or numpy array")
-        
+
         # Validate value shape
         if boundary in [BoundaryType.LEFT, BoundaryType.RIGHT]:
             if values_array.shape != (self._shape[0],):
-                raise ValueError(f"Left/Right boundary values must have shape ({self._shape[0]},), got {values_array.shape}")
+                raise ValueError(
+                    "Left/Right boundary values must have shape "
+                    f"({self._shape[0]},), got {values_array.shape}"
+                )
         else:  # TOP, BOTTOM
             if values_array.shape != (self._shape[1],):
-                raise ValueError(f"Top/Bottom boundary values must have shape ({self._shape[1]},), got {values_array.shape}")
-        
+                raise ValueError(
+                    "Top/Bottom boundary values must have shape "
+                    f"({self._shape[1]},), got {values_array.shape}"
+                )
+
         return values_array
-    
-    def _preprocess_gradients(self, boundary: BoundaryType, gradients: Union[np.ndarray, float, int]) -> np.ndarray:
+
+    def _preprocess_gradients(
+        self, boundary: BoundaryType, gradients: Union[np.ndarray, float, int]
+    ) -> np.ndarray:
         """
         Preprocess gradients to ensure correct format and validate shape.
-        
+
         Args:
             boundary: Boundary type to determine expected shape
             gradients: Input gradients (can be number or numpy array)
-            
+
         Returns:
             Preprocessed numpy array with correct shape and dtype
-            
+
         Raises:
             TypeError: If gradients is not a number or numpy array
             ValueError: If gradients have incompatible shape
@@ -265,52 +299,67 @@ class MeshBlock:
             gradients_array = gradients
         else:
             raise TypeError("gradients must be a number or numpy array")
-        
+
         # Validate gradient shape
         if boundary in [BoundaryType.LEFT, BoundaryType.RIGHT]:
             if gradients_array.shape != (self._shape[0],):
-                raise ValueError(f"Left/Right boundary gradients must have shape ({self._shape[0]},), got {gradients_array.shape}")
+                raise ValueError(
+                    "Left/Right boundary gradients must have shape "
+                    f"({self._shape[0]},), got {gradients_array.shape}"
+                )
         else:  # TOP, BOTTOM
             if gradients_array.shape != (self._shape[1],):
-                raise ValueError(f"Top/Bottom boundary gradients must have shape ({self._shape[1]},), got {gradients_array.shape}")
-        
+                raise ValueError(
+                    "Top/Bottom boundary gradients must have shape "
+                    f"({self._shape[1]},), got {gradients_array.shape}"
+                )
+
         return gradients_array
 
-    def set_boundary_gradients(self, boundary: BoundaryType, gradients: Union[np.ndarray, float, int]) -> None:
+    def set_boundary_gradients(
+        self, boundary: BoundaryType, gradients: Union[np.ndarray, float, int]
+    ) -> None:
         """
         Set boundary gradients by modifying boundary values.
-        
+
         This method works backwards from the desired gradient to determine what values
-        need to be set. It preserves the adjacent interior values and adjusts only the 
+        need to be set. It preserves the adjacent interior values and adjusts only the
         boundary values to achieve the specified gradients.
-        
+
         The gradients are set as:
         - Top gradient: "top line" - "adjacent line below" → adjusts top line
-        - Bottom gradient: "line adjacent to bottom" - "bottom line" → adjusts bottom line
-        - Left gradient: "line adjacent to left" - "left line" → adjusts left line
-        - Right gradient: "right line" - "line adjacent to right" → adjusts right line
-        
+        - Bottom gradient: "line adjacent to bottom" - "bottom line" → adjusts
+          bottom line
+        - Left gradient: "line adjacent to left" - "left line" → adjusts left
+          line
+        - Right gradient: "right line" - "line adjacent to right" → adjusts
+          right line
+
         Args:
             boundary: Boundary to update (must be BoundaryType enum)
             gradients: Desired gradients. Can be:
-                - Single number (float/int) to set all boundary gradients to the same value
+                - Single number (float/int) to set all boundary gradients to the
+                  same value
                 - 1D numpy array with length matching the boundary dimension
-        
+
         Raises:
             TypeError: If boundary is not a BoundaryType enum
-            ValueError: If the mesh block is too small or gradients have incompatible shape
+            ValueError: If the mesh block is too small or gradients have
+                incompatible shape
         """
         # Validate boundary type
         if not isinstance(boundary, BoundaryType):
-            raise TypeError(f"boundary must be a BoundaryType enum, got {type(boundary).__name__}")
-        
+            raise TypeError(
+                f"boundary must be a BoundaryType enum, got {type(boundary).__name__}"
+            )
+
         # Check if the mesh block is large enough to compute gradients
         if self._shape[0] < 2 or self._shape[1] < 2:
             raise ValueError("Mesh block must be at least 2x2 to set gradients")
-        
+
         # Preprocess the gradients to ensure correct format
         gradients_array = self._preprocess_gradients(boundary, gradients)
-        
+
         # Set values to achieve the desired gradients
         if boundary == BoundaryType.TOP:
             # Top gradient: top line - adjacent line below
@@ -332,11 +381,11 @@ class MeshBlock:
             # This should never happen due to the enum validation above
             valid_boundaries = [b.value for b in BoundaryType]
             raise ValueError(f"Boundary must be one of: {valid_boundaries}")
-    
+
     def __repr__(self) -> str:
         """String representation of the MeshBlock."""
         return f"MeshBlock(shape={self._shape}, dtype={self._dtype})"
-    
+
     def __str__(self) -> str:
         """String representation showing the current state."""
-        return f"MeshBlock(shape={self._shape})\nState:\n{self._state}" 
+        return f"MeshBlock(shape={self._shape})\nState:\n{self._state}"

--- a/sandwich_numerical/solver/mesh_utils.py
+++ b/sandwich_numerical/solver/mesh_utils.py
@@ -1,71 +1,76 @@
 from .mesh_block import MeshBlock, BoundaryType
 
 
-def copy_boundary_values(source_block: MeshBlock,
-                        source_boundary: BoundaryType, 
-                        target_block: MeshBlock,
-                        target_boundary: BoundaryType) -> None:
+def copy_boundary_values(
+    source_block: MeshBlock,
+    source_boundary: BoundaryType,
+    target_block: MeshBlock,
+    target_boundary: BoundaryType,
+) -> None:
     """
     Copy boundary values from one mesh block to another.
-    
+
     This function extracts boundary values from the source block and applies
     them to the target block, with optional scaling and offset.
-    
+
     Args:
         source_block (MeshBlock): Source mesh block to copy from
         target_block (MeshBlock): Target mesh block to copy to
         source_boundary (BoundaryType): Boundary of source block to copy from
         target_boundary (BoundaryType): Boundary of target block to copy to
-        
+
     Raises:
         ValueError: If the boundaries have incompatible dimensions
         TypeError: If any arguments have incorrect types
-        
+
     Example:
         # Copy left boundary values from block1 to right boundary of block2
         copy_boundary_values(block1, block2, BoundaryType.LEFT, BoundaryType.RIGHT)
     """
-    
+
     # Get boundary values from source block
     source_values = source_block.get_boundary_values(source_boundary)
-    
+
     # Set boundary values in target block
     target_block.set_boundary_values(target_boundary, source_values)
 
 
-def copy_boundary_gradients(source_block: MeshBlock,
-                           source_boundary: BoundaryType,
-                           target_block: MeshBlock,
-                           target_boundary: BoundaryType,
-                           scaling_factor: float = 1.0) -> None:
+def copy_boundary_gradients(
+    source_block: MeshBlock,
+    source_boundary: BoundaryType,
+    target_block: MeshBlock,
+    target_boundary: BoundaryType,
+    scaling_factor: float = 1.0,
+) -> None:
     """
     Copy boundary gradients from one mesh block to another.
-    
+
     This function extracts boundary gradients from the source block and applies
     them to the target block, with optional scaling. The gradients are applied
     by updating boundary values to achieve the desired gradients.
-    
+
     Args:
         source_block (MeshBlock): Source mesh block to copy from
         target_block (MeshBlock): Target mesh block to copy to
         source_boundary (BoundaryType): Boundary of source block to copy from
         target_boundary (BoundaryType): Boundary of target block to copy to
         scaling_factor (float): Factor to scale the copied gradients (default: 1.0)
-        
+
     Raises:
-        ValueError: If the boundaries have incompatible dimensions or mesh blocks are too small
+        ValueError: If the boundaries have incompatible dimensions or mesh blocks
+            are too small
         TypeError: If any arguments have incorrect types
-        
+
     Example:
         # Copy left boundary gradients from block1 to right boundary of block2
         copy_boundary_gradients(block1, block2, BoundaryType.LEFT, BoundaryType.RIGHT)
     """
-    
+
     # Get boundary gradients from source block
     source_gradients = source_block.get_boundary_gradients(source_boundary)
-    
+
     # Apply scaling and offset
     scaled_gradients = source_gradients * scaling_factor
-    
+
     # Set boundary gradients in target block
     target_block.set_boundary_gradients(target_boundary, scaled_gradients)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-# Tests package 
+# Tests package

--- a/tests/test_mesh_block.py
+++ b/tests/test_mesh_block.py
@@ -9,72 +9,74 @@ from sandwich_numerical.solver.mesh_block import MeshBlock, BoundaryType
 
 class TestMeshBlock:
     """Test cases for the MeshBlock class."""
-    
+
     @pytest.fixture
     def sample_block(self):
         """Create a sample MeshBlock for testing."""
         return MeshBlock((3, 4), dtype=np.float64)
-    
+
     @pytest.fixture
     def large_block(self):
         """Create a larger MeshBlock for testing."""
         return MeshBlock((5, 7), dtype=np.float32)
-    
+
     def test_creation_with_valid_shapes(self):
         """Test that MeshBlock objects can be created with valid shapes."""
         # Test various valid shapes
         block1 = MeshBlock((2, 3))
         assert block1.shape == (2, 3)
         assert block1.dtype == np.float64
-        
+
         block2 = MeshBlock((10, 5), dtype=np.float32)
         assert block2.shape == (10, 5)
         assert block2.dtype == np.float32
-        
+
         block3 = MeshBlock((1, 100))
         assert block3.shape == (1, 100)
-        
+
         block4 = MeshBlock((100, 1))
         assert block4.shape == (100, 1)
-    
+
     def test_initial_state(self, sample_block):
         """Test that the initial state is properly initialized."""
         assert sample_block.state.shape == (3, 4)
         assert sample_block.state.dtype == np.float64
         assert np.all(sample_block.state == 0.0)
         assert sample_block.state is not sample_block._state  # Should be a view
-    
+
     def test_properties(self, sample_block):
         """Test that all properties return correct values."""
         assert sample_block.shape == (3, 4)
         assert sample_block.dtype == np.float64
         assert sample_block.state.shape == (3, 4)
-    
+
     def test_set_state_with_valid_array(self, sample_block):
         """Test setting state with a valid numpy array."""
-        new_state = np.array([[1.0, 2.0, 3.0, 4.0],
-                             [5.0, 6.0, 7.0, 8.0],
-                             [9.0, 10.0, 11.0, 12.0]])
-        
+        new_state = np.array(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]
+        )
+
         sample_block.set_state(new_state)
-        
+
         # Check that the state was updated
         assert np.array_equal(sample_block.state, new_state)
         # Check that it's the same array (in-place update)
         assert sample_block.state is not new_state
-    
+
     def test_set_state_with_different_dtype(self, sample_block):
         """Test setting state with an array of different dtype."""
-        new_state = np.array([[1, 2, 3, 4],
-                             [5, 6, 7, 8],
-                             [9, 10, 11, 12]], dtype=np.int32)
-        
+        new_state = np.array(
+            [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], dtype=np.int32
+        )
+
         sample_block.set_state(new_state)
-        
+
         # Check that the state was updated and dtype was converted
         assert np.array_equal(sample_block.state, new_state)
-        assert sample_block.state.dtype == np.float64  # Should be converted to block's dtype
-    
+        assert (
+            sample_block.state.dtype == np.float64
+        )  # Should be converted to block's dtype
+
     def test_set_boundary_values_with_single_values(self, sample_block):
         """Test setting boundary values with single numbers."""
         # Test setting all boundaries to the same value
@@ -82,14 +84,18 @@ class TestMeshBlock:
         sample_block.set_boundary_values(BoundaryType.RIGHT, 10.0)
         sample_block.set_boundary_values(BoundaryType.TOP, 15.0)
         sample_block.set_boundary_values(BoundaryType.BOTTOM, 20.0)
-        
+
         # Check that boundaries were set correctly
         # Note: TOP and BOTTOM overwrite the corners of LEFT and RIGHT
-        assert sample_block.state[1, 0] == 5.0   # Left (middle row)
+        assert sample_block.state[1, 0] == 5.0  # Left (middle row)
         assert sample_block.state[1, -1] == 10.0  # Right (middle row)
-        assert np.all(sample_block.state[-1, :] == 15.0)   # Top (overwrites left/right corners)
-        assert np.all(sample_block.state[0, :] == 20.0)  # Bottom (overwrites left/right corners)
-    
+        assert np.all(
+            sample_block.state[-1, :] == 15.0
+        )  # Top (overwrites left/right corners)
+        assert np.all(
+            sample_block.state[0, :] == 20.0
+        )  # Bottom (overwrites left/right corners)
+
     def test_set_boundary_values_with_arrays(self, sample_block):
         """Test setting boundary values with numpy arrays."""
         # Create arrays for each boundary
@@ -97,45 +103,47 @@ class TestMeshBlock:
         right_values = np.array([4.0, 5.0, 6.0])
         top_values = np.array([7.0, 8.0, 9.0, 10.0])
         bottom_values = np.array([11.0, 12.0, 13.0, 14.0])
-        
+
         # Set boundary values
         sample_block.set_boundary_values(BoundaryType.LEFT, left_values)
         sample_block.set_boundary_values(BoundaryType.RIGHT, right_values)
         sample_block.set_boundary_values(BoundaryType.TOP, top_values)
         sample_block.set_boundary_values(BoundaryType.BOTTOM, bottom_values)
-        
+
         # Check that boundaries were set correctly
         # Note: TOP and BOTTOM overwrite the corners of LEFT and RIGHT
         # The final state should be:
         # Top row: [7, 8, 9, 10] (overwrites left/right corners)
         # Middle row: [1, 0, 0, 4] (left and right boundaries)
         # Bottom row: [11, 12, 13, 14] (overwrites left/right corners)
-        
+
         # Check top row (completely overwritten by TOP)
         np.testing.assert_array_equal(sample_block.state[-1, :], top_values)
-        
+
         # Check middle row (LEFT and RIGHT boundaries, not overwritten by TOP/BOTTOM)
         assert sample_block.state[1, 0] == left_values[1]  # Left boundary
         assert sample_block.state[1, -1] == right_values[1]  # Right boundary
-        
+
         # Check bottom row (completely overwritten by BOTTOM)
         np.testing.assert_array_equal(sample_block.state[0, :], bottom_values)
-    
+
     def test_boundary_values_with_different_dtypes(self, sample_block):
         """Test setting boundary values with different data types."""
         # Test with integer values
         sample_block.set_boundary_values(BoundaryType.LEFT, 5)
-        assert sample_block.state[1, 0] == 5.0  # Should be converted to float (middle row)
-        
+        assert (
+            sample_block.state[1, 0] == 5.0
+        )  # Should be converted to float (middle row)
+
         # Test with float values
         sample_block.set_boundary_values(BoundaryType.RIGHT, 10.5)
         assert sample_block.state[1, -1] == 10.5  # Middle row
-        
+
         # Test with numpy arrays of different dtypes
         int_array = np.array([1, 2, 3, 4], dtype=np.int32)  # Must match width (4)
         sample_block.set_boundary_values(BoundaryType.TOP, int_array)
         assert np.all(sample_block.state[-1, :] == [1.0, 2.0, 3.0, 4.0])  # Top row
-    
+
     def test_get_boundary_values(self, sample_block):
         """Test getting boundary values."""
         # Set some boundary values first
@@ -143,85 +151,81 @@ class TestMeshBlock:
         sample_block.set_boundary_values(BoundaryType.RIGHT, 10.0)
         sample_block.set_boundary_values(BoundaryType.TOP, 15.0)
         sample_block.set_boundary_values(BoundaryType.BOTTOM, 20.0)
-        
+
         # Get boundary values
         left_values = sample_block.get_boundary_values(BoundaryType.LEFT)
         right_values = sample_block.get_boundary_values(BoundaryType.RIGHT)
         top_values = sample_block.get_boundary_values(BoundaryType.TOP)
         bottom_values = sample_block.get_boundary_values(BoundaryType.BOTTOM)
-        
+
         # Check that returned values are correct
         # Note: TOP and BOTTOM overwrite the corners of LEFT and RIGHT
         assert left_values[1] == 5.0  # Middle row (not overwritten by TOP/BOTTOM)
         assert right_values[1] == 10.0  # Middle row (not overwritten by TOP/BOTTOM)
         assert np.all(top_values == 15.0)  # Top row
         assert np.all(bottom_values == 20.0)  # Bottom row
-        
+
         # Check that returned arrays are copies, not views
         assert left_values is not sample_block.state[:, 0]
         assert right_values is not sample_block.state[:, -1]
         assert top_values is not sample_block.state[-1, :]
         assert bottom_values is not sample_block.state[0, :]
-    
+
     def test_get_boundary_values_with_enum_values(self, sample_block):
         """Test getting boundary values using enum values."""
         # Set boundary values
         sample_block.set_boundary_values(BoundaryType.LEFT, 5.0)
-        
+
         # Get using enum value
         left_values = sample_block.get_boundary_values(BoundaryType.LEFT)
         assert np.all(left_values == 5.0)
-    
+
     def test_get_boundary_gradients(self):
         """Test getting boundary gradients."""
         # Create a mesh block with known values
         mesh = MeshBlock((3, 3))
-        
+
         # Set up a simple state with known gradients
-        state = np.array([[1.0, 2.0, 3.0],
-                         [4.0, 5.0, 6.0],
-                         [7.0, 8.0, 9.0]])
+        state = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
         mesh.set_state(state)
-        
+
         # Test gradients
         top_grad = mesh.get_boundary_gradients(BoundaryType.TOP)
         np.testing.assert_array_equal(top_grad, np.array([3.0, 3.0, 3.0]))
-        
+
         bottom_grad = mesh.get_boundary_gradients(BoundaryType.BOTTOM)
         np.testing.assert_array_equal(bottom_grad, np.array([3.0, 3.0, 3.0]))
-        
+
         left_grad = mesh.get_boundary_gradients(BoundaryType.LEFT)
         np.testing.assert_array_equal(left_grad, np.array([1.0, 1.0, 1.0]))
-        
+
         right_grad = mesh.get_boundary_gradients(BoundaryType.RIGHT)
         np.testing.assert_array_equal(right_grad, np.array([1.0, 1.0, 1.0]))
-    
+
     def test_set_boundary_gradients(self):
         """Test setting boundary gradients."""
         # Create a mesh block
         mesh = MeshBlock((3, 3))
-        
+
         # Set up initial state
-        state = np.array([[1.0, 2.0, 3.0],
-                         [4.0, 5.0, 6.0],
-                         [7.0, 8.0, 9.0]])
+        state = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
         mesh.set_state(state)
-        
+
         # Test setting top gradient
         mesh.set_boundary_gradients(BoundaryType.TOP, np.array([0.5, 1.0, 1.5]))
         top_grad = mesh.get_boundary_gradients(BoundaryType.TOP)
         np.testing.assert_array_equal(top_grad, np.array([0.5, 1.0, 1.5]))
-        
+
         # Test setting right gradient
         mesh.set_boundary_gradients(BoundaryType.RIGHT, np.array([-1.0, -1.0, -1.0]))
         right_grad = mesh.get_boundary_gradients(BoundaryType.RIGHT)
         np.testing.assert_array_equal(right_grad, np.array([-1.0, -1.0, -1.0]))
-        
+
         # Test setting bottom gradient
         mesh.set_boundary_gradients(BoundaryType.BOTTOM, np.array([0.5, 1.0, 1.5]))
         bottom_grad = mesh.get_boundary_gradients(BoundaryType.BOTTOM)
         np.testing.assert_array_equal(bottom_grad, np.array([0.5, 1.0, 1.5]))
-    
+
     def test_repr_and_str(self, sample_block):
         """Test string representations."""
         # Test __repr__
@@ -229,12 +233,13 @@ class TestMeshBlock:
         assert "MeshBlock" in repr_str
         assert "shape=(3, 4)" in repr_str
         assert "dtype=" in repr_str
-        
+
         # Test __str__
         str_str = str(sample_block)
         assert "MeshBlock" in str_str
         assert "State:" in str_str
         assert "shape=(3, 4)" in str_str
 
+
 if __name__ == "__main__":
-    pytest.main([__file__]) 
+    pytest.main([__file__])

--- a/tests/test_sandwich.py
+++ b/tests/test_sandwich.py
@@ -9,61 +9,110 @@ from sandwich_numerical.sandwich import Sandwich
 
 class TestSandwich:
     """Test cases for the Sandwich class."""
-    
+
     @pytest.fixture
     def sample_mesh(self):
         """Create a sample Sandwich mesh for testing."""
         block_size = (10, 10)  # (height, width) tuple
         grid_step = 0.1
         grad_factor = 1.0
-    
-        # Create simple gradient vector - should be 1D with length 3*block_height + 1
-        grad_vec = np.linspace(0, 1, 3 * block_size[0] + 1)
-    
+
+        # Create simple gradient vector - should be 1D with length 3*block_height
+        grad_vec = np.linspace(0, 1, 3 * block_size[0])
+
         return Sandwich(
             block_size=block_size,
             grad_vec=grad_vec,
             grid_step=grid_step,
-            grad_factor=grad_factor
+            grad_factor=grad_factor,
         )
-    
+
     def test_creation(self, sample_mesh):
         """Test that Sandwich objects can be created."""
         assert sample_mesh.block_size == (10, 10)
         assert sample_mesh.grid_step == 0.1
         assert sample_mesh.grad_factor == 1.0
-        assert sample_mesh.grad_vec.shape == (31,)  # 3*block_height + 1 = 3*10 + 1 = 31
-    
+        assert sample_mesh.grad_vec.shape == (30,)  # 3*block_height = 3*10 = 30
+
     def test_state_arrays(self, sample_mesh):
         """Test that state arrays are properly initialized."""
         assert sample_mesh.bottom.state.shape == (10, 10)
-        assert sample_mesh.mid.state.shape == (12, 10)  # +2 rows for boundary conditions
+        assert sample_mesh.mid.state.shape == (12, 10)
         assert sample_mesh.top.state.shape == (10, 10)
-    
+
     def test_step_method(self, sample_mesh):
         """Test that the step method executes without error."""
         initial_residual = sample_mesh.get_residual()
         sample_mesh.step()
         new_residual = sample_mesh.get_residual()
-        
+
         # Initial residual should be 0.0 (all arrays start as zeros)
         assert initial_residual == 0.0
         # After one step, residual should be non-zero as the system evolves
         assert new_residual > 0.0
         # Step method should execute without error
         assert isinstance(new_residual, (int, float))
-    
+
     def test_displacement_array(self, sample_mesh):
         """Test that displacement array has correct shape."""
         displacement = sample_mesh.get_displacement_array()
         assert displacement.shape == (30, 10)  # 3 blocks * 10 rows
-    
+
     def test_plot_method(self, sample_mesh):
         """Test that plot method returns a plotly figure."""
         fig = sample_mesh.plot()
         assert fig is not None
         # Additional plot-specific assertions could be added here
 
+    @pytest.mark.parametrize("grad_vec_length", [29, 31])
+    def test_invalid_grad_vec_length(self, grad_vec_length):
+        """Test that invalid gradient vector lengths are rejected."""
+        block_size = (10, 10)
+        grad_vec = np.linspace(0, 1, grad_vec_length)
+
+        with pytest.raises(ValueError, match="grad_vec"):
+            Sandwich(
+                block_size=block_size, grad_vec=grad_vec, grid_step=0.1, grad_factor=1.0
+            )
+
+    @pytest.mark.parametrize("grad_factor", [0.0, -1.0])
+    def test_invalid_grad_factor(self, grad_factor):
+        """Test that invalid gradient factors are rejected."""
+        block_size = (10, 10)
+        grad_vec = np.linspace(0, 1, 3 * block_size[0])
+
+        with pytest.raises(ValueError, match="grad_factor"):
+            Sandwich(
+                block_size=block_size,
+                grad_vec=grad_vec,
+                grid_step=0.1,
+                grad_factor=grad_factor,
+            )
+
+    @pytest.mark.parametrize("grid_step", [0.0, -0.1])
+    def test_invalid_grid_step(self, grid_step):
+        """Test that invalid grid steps are rejected."""
+        block_size = (10, 10)
+        grad_vec = np.linspace(0, 1, 3 * block_size[0])
+
+        with pytest.raises(ValueError, match="grid_step"):
+            Sandwich(
+                block_size=block_size,
+                grad_vec=grad_vec,
+                grid_step=grid_step,
+                grad_factor=1.0,
+            )
+
+    @pytest.mark.parametrize("block_size", [(1, 10), (10, 1)])
+    def test_invalid_block_size(self, block_size):
+        """Test that block sizes too small for gradients are rejected."""
+        grad_vec = np.linspace(0, 1, 3 * block_size[0])
+
+        with pytest.raises(ValueError, match="block_size"):
+            Sandwich(
+                block_size=block_size, grad_vec=grad_vec, grid_step=0.1, grad_factor=1.0
+            )
+
 
 if __name__ == "__main__":
-    pytest.main([__file__]) 
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

- Remove the broken `sandwich-demo` Poetry script that pointed to a missing module.
- Align the documented and tested `grad_vec` contract with the implementation: `3 * block_height`.
- Add early `Sandwich` parameter validation for block size, gradient vector shape, grid step, and gradient factor.
- Add black, flake8, and mypy as CI gates, plus flake8 configuration compatible with black.
- Format the package and tests and add type annotations needed for strict mypy to pass.

## Why

The project had a few maintenance hazards: a non-working CLI entrypoint, a stale `grad_vec` length contract, late runtime failures for invalid solver parameters, and quality tools that were documented/configured but not enforced by CI.

## Validation

- `python -m black --check sandwich_numerical tests`
- `python -m flake8 sandwich_numerical tests`
- `poetry run mypy sandwich_numerical`
- `poetry run pytest -q`