### PR TITLE
[codex] add parabolic zero mean load profile

### DIFF
--- a/sandwich_numerical/integration.py
+++ b/sandwich_numerical/integration.py
@@ -40,6 +40,13 @@ class SandwichSolution:
 
 ProgressCallback = Callable[[int, float | None], None]
 
+GRADIENT_PROFILE_SINE = "sine"
+GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN = "parabolic_zero_mean"
+GRADIENT_PROFILES = (
+    GRADIENT_PROFILE_SINE,
+    GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
+)
+
 
 SANDWICH_RUNS: tuple[SandwichRun, ...] = (
     SandwichRun(
@@ -138,9 +145,16 @@ def create_sandwich(run: SandwichRun) -> Sandwich:
 
 def build_gradient_vector(run: SandwichRun) -> np.ndarray:
     mesh_height = run.block_height * len(run.grad_factors)
-    if run.gradient_profile != "sine":
+
+    if run.gradient_profile == GRADIENT_PROFILE_SINE:
+        gradient = np.sin((2 * np.pi) / (mesh_height - 1) * np.arange(mesh_height))
+    elif run.gradient_profile == GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN:
+        full_thickness = (mesh_height - 1) * run.grid_step
+        x = np.linspace(-full_thickness / 2, full_thickness / 2, mesh_height)
+        gradient = x**2 - full_thickness**2 / 12
+    else:
         raise ValueError(f"Unsupported gradient profile: {run.gradient_profile}")
-    gradient = np.sin((2 * np.pi) / (mesh_height - 1) * np.arange(mesh_height))
+
     return np.asarray(gradient, dtype=float)
 
 

--- a/scripts/run_sandwich_integration.py
+++ b/scripts/run_sandwich_integration.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-"""Run the Sandwich integration scenarios and save reproducible artifacts.
-
-The configured cases use sandwiches with the same sinusoidal boundary gradient
-and different full-block gradient factor sets.
-"""
+"""Run the Sandwich integration scenarios and save reproducible artifacts."""
 
 from __future__ import annotations
 
@@ -31,6 +27,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from sandwich_numerical.integration import (
+    GRADIENT_PROFILES,
     SANDWICH_RUNS,
     SandwichRun,
     SandwichSolution,
@@ -90,6 +87,11 @@ def parse_args() -> argparse.Namespace:
         type=float,
         help="Under-relaxation for copied interface gradients.",
     )
+    parser.add_argument(
+        "--gradient-profile",
+        choices=GRADIENT_PROFILES,
+        help="Override the boundary gradient profile for selected sandwiches.",
+    )
     overlap_group = parser.add_mutually_exclusive_group()
     overlap_group.add_argument(
         "--enforce-overlap-continuity",
@@ -142,6 +144,10 @@ def prepare_runs(args: argparse.Namespace) -> tuple[SandwichRun, ...]:
             )
         if args.gradient_relaxation is not None:
             replacements["gradient_relaxation"] = args.gradient_relaxation
+        if args.gradient_profile is not None:
+            replacements["gradient_profile"] = args.gradient_profile
+            if args.gradient_profile != run.gradient_profile:
+                replacements["name"] = f"{run.name}_{args.gradient_profile}"
         if args.enforce_overlap_continuity is not None:
             replacements["enforce_overlap_continuity"] = args.enforce_overlap_continuity
         prepared.append(dataclasses.replace(run, **replacements))
@@ -168,6 +174,7 @@ def run_case(
         f"({run.block_height}, {run.block_width}), "
         f"grid_step={run.grid_step}, "
         f"grad_factors={run.grad_factors}, "
+        f"gradient_profile={run.gradient_profile}, "
         f"gradient_relaxation={run.gradient_relaxation}, "
         f"enforce_overlap_continuity={run.enforce_overlap_continuity}, "
         f"iterations={run.iterations}"

--- a/scripts/run_sandwich_integration.py
+++ b/scripts/run_sandwich_integration.py
@@ -38,6 +38,7 @@ from sandwich_numerical.integration import (
 
 FIGURE_WIDTH = 1120
 FIGURE_HEIGHT = 650
+DISPLACEMENT_CMAP = "bwr"
 
 
 def main() -> None:
@@ -262,7 +263,7 @@ def make_heatmap_figure(
     image = ax.imshow(
         data,
         aspect="auto",
-        cmap="RdBu_r",
+        cmap=DISPLACEMENT_CMAP,
         norm=make_displacement_norm(data),
         origin="lower",
     )
@@ -333,10 +334,10 @@ def make_displacement_norm(data: np.ndarray):
         return None
     min_value = float(finite.min())
     max_value = float(finite.max())
-    if min_value < 0 < max_value:
-        limit = max(abs(min_value), abs(max_value))
-        return TwoSlopeNorm(vmin=-limit, vcenter=0, vmax=limit)
-    return None
+    limit = max(abs(min_value), abs(max_value))
+    if limit == 0:
+        limit = 1.0
+    return TwoSlopeNorm(vmin=-limit, vcenter=0, vmax=limit)
 
 
 def write_figure_png(

--- a/tests/test_sandwich_integration_e2e.py
+++ b/tests/test_sandwich_integration_e2e.py
@@ -2,12 +2,15 @@
 
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 
 from sandwich_numerical.integration import (
+    GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
     SANDWICH_RUNS,
     SandwichRun,
+    build_gradient_vector,
     parameters_data_to_df,
     solve_case,
 )
@@ -51,6 +54,34 @@ def test_layer_boundary_sample_coordinates_match_discrete_row_boundaries() -> No
     assert layer_boundary_x2(run).tolist() == pytest.approx(
         [0.1025, 0.2075, 0.3125, 0.4175]
     )
+
+
+def test_parabolic_zero_mean_gradient_profile_matches_formula() -> None:
+    run = SandwichRun(
+        name="parabolic_zero_mean",
+        block_height=7,
+        block_width=10,
+        grid_step=0.25,
+        grad_factors=(1.0, 1.0, 1.0),
+        iterations=0,
+        residual_every=1,
+        progress_every=1,
+        heatmap_columns=10,
+        detail_heatmap_columns=10,
+        sample_x1_positions=(0.0,),
+        gradient_profile=GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
+    )
+
+    actual = build_gradient_vector(run)
+    mesh_height = run.block_height * len(run.grad_factors)
+    full_thickness = (mesh_height - 1) * run.grid_step
+    x = np.linspace(-full_thickness / 2, full_thickness / 2, mesh_height)
+    expected = x**2 - full_thickness**2 / 12
+
+    np.testing.assert_allclose(actual, expected, rtol=0, atol=1e-15)
+    np.testing.assert_allclose(actual, actual[::-1], rtol=0, atol=1e-15)
+    analytic_integral = full_thickness**3 / 12 - full_thickness * full_thickness**2 / 12
+    assert analytic_integral == pytest.approx(0.0, abs=1e-15)
 
 
 def assert_numeric_frame_matches_csv(actual: pd.DataFrame, path: Path) -> None:

--- a/tests/test_sandwich_integration_e2e.py
+++ b/tests/test_sandwich_integration_e2e.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
@@ -14,7 +15,13 @@ from sandwich_numerical.integration import (
     parameters_data_to_df,
     solve_case,
 )
-from scripts.run_sandwich_integration import layer_boundary_rows, layer_boundary_x2
+from scripts.run_sandwich_integration import (
+    DISPLACEMENT_CMAP,
+    layer_boundary_rows,
+    layer_boundary_x2,
+    make_displacement_norm,
+    make_heatmap_figure,
+)
 
 
 BASELINE_DIR = Path(__file__).resolve().parent / "fixtures/sandwich_integration"
@@ -84,6 +91,38 @@ def test_parabolic_zero_mean_gradient_profile_matches_formula() -> None:
         full_thickness**3 / 12 - full_thickness * full_thickness**2 / 12
     )
     assert analytic_integral == pytest.approx(0.0, abs=1e-15)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        np.array([[-2.0, 0.0, 1.0]]),
+        np.array([[0.0, 1.0, 2.0]]),
+        np.array([[-2.0, -1.0, 0.0]]),
+        np.zeros((2, 3)),
+    ],
+)
+def test_displacement_heatmap_norm_centers_zero(data: np.ndarray) -> None:
+    norm = make_displacement_norm(data)
+
+    assert norm is not None
+    assert norm(0.0) == pytest.approx(0.5)
+    assert norm.vmin == pytest.approx(-norm.vmax)
+    assert norm.vcenter == 0
+
+
+def test_displacement_heatmap_uses_white_center_colormap() -> None:
+    fig = make_heatmap_figure(np.array([[-1.0, 0.0, 1.0]]), "displacement")
+    try:
+        image = fig.axes[0].images[0]
+
+        assert image.cmap.name == DISPLACEMENT_CMAP
+        assert image.cmap(image.norm(0.0))[:3] == pytest.approx(
+            (1.0, 1.0, 1.0),
+            abs=0.01,
+        )
+    finally:
+        plt.close(fig)
 
 
 def assert_numeric_frame_matches_csv(actual: pd.DataFrame, path: Path) -> None:

--- a/tests/test_sandwich_integration_e2e.py
+++ b/tests/test_sandwich_integration_e2e.py
@@ -80,7 +80,9 @@ def test_parabolic_zero_mean_gradient_profile_matches_formula() -> None:
 
     np.testing.assert_allclose(actual, expected, rtol=0, atol=1e-15)
     np.testing.assert_allclose(actual, actual[::-1], rtol=0, atol=1e-15)
-    analytic_integral = full_thickness**3 / 12 - full_thickness * full_thickness**2 / 12
+    analytic_integral = (
+        full_thickness**3 / 12 - full_thickness * full_thickness**2 / 12
+    )
     assert analytic_integral == pytest.approx(0.0, abs=1e-15)
 
 


### PR DESCRIPTION
## Summary

Adds a new `parabolic_zero_mean` boundary gradient profile for Sandwich integration runs. The profile uses the centered thickness coordinate and evaluates `f(x) = x^2 - H^2 / 12`, so its analytic integral over the full thickness is zero.

The integration runner now accepts `--gradient-profile`, appends the profile name to generated case directories when overriding the default, and prints the selected profile in run logs. This lets the parabolic runs generate local artifacts without overwriting the existing sine artifacts.

## Generated artifacts

Ran `python3 scripts/run_sandwich_integration.py --gradient-profile parabolic_zero_mean`, which produced local artifacts under:

- `artifacts/sandwich_integration/grad_factors_1_1_1_parabolic_zero_mean`
- `artifacts/sandwich_integration/grad_factors_1_1000_1_parabolic_zero_mean`
- `artifacts/sandwich_integration/grad_factors_1000_1_1000_1_1000_parabolic_zero_mean`

`artifacts/` is gitignored, so these generated CSV/PNG files are not included in the PR.

Final residuals from the generated runs:

- `grad_factors_1_1_1_parabolic_zero_mean`: `7.1578086999669955e-06`
- `grad_factors_1_1000_1_parabolic_zero_mean`: `2.706558068969536e-04`
- `grad_factors_1000_1_1000_1_1000_parabolic_zero_mean`: `2.9237174246377045e-03`

## Validation

- `python3 -m pytest tests/test_sandwich_integration_e2e.py -q`
- `python3 -m pytest tests/test_sandwich_integration_e2e.py::test_parabolic_zero_mean_gradient_profile_matches_formula -q`
- `python3 scripts/run_sandwich_integration.py --gradient-profile parabolic_zero_mean`
- `git diff --check`

Note: the pytest runs emit the existing pandas/bottleneck environment warning.