### PR TITLE
[codex] add sandwich integration artifact workflow

### DIFF
--- a/.github/workflows/sandwich-integration-artifacts.yml
+++ b/.github/workflows/sandwich-integration-artifacts.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   generate:
     if: github.event.pull_request.merged == true
-    name: ${{ matrix.scenario_name }}
+    name: ${{ matrix.case }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -16,30 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - case: grad_factors_1_1_1
-            gradient_profile: sine
-            scenario_name: grad_factors_1_1_1_load_sin
-            artifact_name: sandwich-integration-grad-factors-1-1-1-load-sin
-          - case: grad_factors_1_1_1
-            gradient_profile: parabolic_zero_mean
-            scenario_name: grad_factors_1_1_1_load_parabolic
-            artifact_name: sandwich-integration-grad-factors-1-1-1-load-parabolic
-          - case: grad_factors_1_1000_1
-            gradient_profile: sine
-            scenario_name: grad_factors_1_1000_1_load_sin
-            artifact_name: sandwich-integration-grad-factors-1-1000-1-load-sin
-          - case: grad_factors_1_1000_1
-            gradient_profile: parabolic_zero_mean
-            scenario_name: grad_factors_1_1000_1_load_parabolic
-            artifact_name: sandwich-integration-grad-factors-1-1000-1-load-parabolic
-          - case: grad_factors_1000_1_1000_1_1000
-            gradient_profile: sine
-            scenario_name: grad_factors_1000_1_1000_1_1000_load_sin
-            artifact_name: sandwich-integration-grad-factors-1000-1-1000-1-1000-load-sin
-          - case: grad_factors_1000_1_1000_1_1000
-            gradient_profile: parabolic_zero_mean
-            scenario_name: grad_factors_1000_1_1000_1_1000_load_parabolic
-            artifact_name: sandwich-integration-grad-factors-1000-1-1000-1-1000-load-parabolic
+          - case: grad_factors_1_1_1_load_sin
+          - case: grad_factors_1_1_1_load_parabolic
+          - case: grad_factors_1_1000_1_load_sin
+          - case: grad_factors_1_1000_1_load_parabolic
+          - case: grad_factors_1000_1_1000_1_1000_load_sin
+          - case: grad_factors_1000_1_1000_1_1000_load_parabolic
 
     steps:
       - uses: actions/checkout@v4
@@ -76,13 +58,12 @@ jobs:
         run: |
           poetry run python scripts/run_sandwich_integration.py \
             --case "${{ matrix.case }}" \
-            --gradient-profile "${{ matrix.gradient_profile }}" \
             --output-dir artifacts/sandwich_integration
 
       - name: Upload Sandwich integration artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact_name }}
-          path: artifacts/sandwich_integration/${{ matrix.scenario_name }}
+          name: sandwich-integration-${{ matrix.case }}
+          path: artifacts/sandwich_integration/${{ matrix.case }}
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/sandwich-integration-artifacts.yml
+++ b/.github/workflows/sandwich-integration-artifacts.yml
@@ -1,0 +1,100 @@
+name: Sandwich Integration Artifacts
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ closed ]
+
+jobs:
+  generate:
+    if: github.event.pull_request.merged == true
+    name: ${{ matrix.case_label }} / ${{ matrix.profile_label }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - case: grad_factors_1_1_1
+            case_label: "(1, 1, 1)"
+            gradient_profile: sine
+            profile_label: sin
+            artifact_dir: grad_factors_1_1_1_sin
+            artifact_name: sandwich-integration-1-1-1-sin
+          - case: grad_factors_1_1_1
+            case_label: "(1, 1, 1)"
+            gradient_profile: parabolic_zero_mean
+            profile_label: parabolic
+            artifact_dir: grad_factors_1_1_1_parabolic
+            artifact_name: sandwich-integration-1-1-1-parabolic
+          - case: grad_factors_1_1000_1
+            case_label: "(1, 1000, 1)"
+            gradient_profile: sine
+            profile_label: sin
+            artifact_dir: grad_factors_1_1000_1_sin
+            artifact_name: sandwich-integration-1-1000-1-sin
+          - case: grad_factors_1_1000_1
+            case_label: "(1, 1000, 1)"
+            gradient_profile: parabolic_zero_mean
+            profile_label: parabolic
+            artifact_dir: grad_factors_1_1000_1_parabolic
+            artifact_name: sandwich-integration-1-1000-1-parabolic
+          - case: grad_factors_1000_1_1000_1_1000
+            case_label: "(1000, 1, 1000, 1, 1000)"
+            gradient_profile: sine
+            profile_label: sin
+            artifact_dir: grad_factors_1000_1_1000_1_1000_sin
+            artifact_name: sandwich-integration-1000-1-1000-1-1000-sin
+          - case: grad_factors_1000_1_1000_1_1000
+            case_label: "(1000, 1, 1000, 1, 1000)"
+            gradient_profile: parabolic_zero_mean
+            profile_label: parabolic
+            artifact_dir: grad_factors_1000_1_1000_1_1000_parabolic
+            artifact_name: sandwich-integration-1000-1-1000-1-1000-parabolic
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: sandwich-integration-venv-${{ runner.os }}-3.11-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+
+      - name: Install project
+        run: poetry install --no-interaction --only-root
+
+      - name: Generate Sandwich integration artifacts
+        run: |
+          poetry run python scripts/run_sandwich_integration.py \
+            --case "${{ matrix.case }}" \
+            --gradient-profile "${{ matrix.gradient_profile }}" \
+            --output-dir "artifacts/sandwich_integration/${{ matrix.artifact_dir }}"
+
+      - name: Upload Sandwich integration artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: artifacts/sandwich_integration/${{ matrix.artifact_dir }}
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/sandwich-integration-artifacts.yml
+++ b/.github/workflows/sandwich-integration-artifacts.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   generate:
     if: github.event.pull_request.merged == true
-    name: ${{ matrix.case_label }} / ${{ matrix.profile_label }}
+    name: ${{ matrix.scenario_name }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -17,41 +17,29 @@ jobs:
       matrix:
         include:
           - case: grad_factors_1_1_1
-            case_label: "(1, 1, 1)"
             gradient_profile: sine
-            profile_label: sin
-            artifact_dir: grad_factors_1_1_1_sin
-            artifact_name: sandwich-integration-1-1-1-sin
+            scenario_name: grad_factors_1_1_1_load_sin
+            artifact_name: sandwich-integration-grad-factors-1-1-1-load-sin
           - case: grad_factors_1_1_1
-            case_label: "(1, 1, 1)"
             gradient_profile: parabolic_zero_mean
-            profile_label: parabolic
-            artifact_dir: grad_factors_1_1_1_parabolic
-            artifact_name: sandwich-integration-1-1-1-parabolic
+            scenario_name: grad_factors_1_1_1_load_parabolic
+            artifact_name: sandwich-integration-grad-factors-1-1-1-load-parabolic
           - case: grad_factors_1_1000_1
-            case_label: "(1, 1000, 1)"
             gradient_profile: sine
-            profile_label: sin
-            artifact_dir: grad_factors_1_1000_1_sin
-            artifact_name: sandwich-integration-1-1000-1-sin
+            scenario_name: grad_factors_1_1000_1_load_sin
+            artifact_name: sandwich-integration-grad-factors-1-1000-1-load-sin
           - case: grad_factors_1_1000_1
-            case_label: "(1, 1000, 1)"
             gradient_profile: parabolic_zero_mean
-            profile_label: parabolic
-            artifact_dir: grad_factors_1_1000_1_parabolic
-            artifact_name: sandwich-integration-1-1000-1-parabolic
+            scenario_name: grad_factors_1_1000_1_load_parabolic
+            artifact_name: sandwich-integration-grad-factors-1-1000-1-load-parabolic
           - case: grad_factors_1000_1_1000_1_1000
-            case_label: "(1000, 1, 1000, 1, 1000)"
             gradient_profile: sine
-            profile_label: sin
-            artifact_dir: grad_factors_1000_1_1000_1_1000_sin
-            artifact_name: sandwich-integration-1000-1-1000-1-1000-sin
+            scenario_name: grad_factors_1000_1_1000_1_1000_load_sin
+            artifact_name: sandwich-integration-grad-factors-1000-1-1000-1-1000-load-sin
           - case: grad_factors_1000_1_1000_1_1000
-            case_label: "(1000, 1, 1000, 1, 1000)"
             gradient_profile: parabolic_zero_mean
-            profile_label: parabolic
-            artifact_dir: grad_factors_1000_1_1000_1_1000_parabolic
-            artifact_name: sandwich-integration-1000-1-1000-1-1000-parabolic
+            scenario_name: grad_factors_1000_1_1000_1_1000_load_parabolic
+            artifact_name: sandwich-integration-grad-factors-1000-1-1000-1-1000-load-parabolic
 
     steps:
       - uses: actions/checkout@v4
@@ -89,12 +77,12 @@ jobs:
           poetry run python scripts/run_sandwich_integration.py \
             --case "${{ matrix.case }}" \
             --gradient-profile "${{ matrix.gradient_profile }}" \
-            --output-dir "artifacts/sandwich_integration/${{ matrix.artifact_dir }}"
+            --output-dir artifacts/sandwich_integration
 
       - name: Upload Sandwich integration artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
-          path: artifacts/sandwich_integration/${{ matrix.artifact_dir }}
+          path: artifacts/sandwich_integration/${{ matrix.scenario_name }}
           if-no-files-found: error
           retention-days: 30

--- a/scripts/run_sandwich_integration.py
+++ b/scripts/run_sandwich_integration.py
@@ -47,6 +47,27 @@ LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE = {
 }
 
 
+def case_name_for_gradient_profile(case_name: str, gradient_profile: str) -> str:
+    return f"{case_name}_{LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE[gradient_profile]}"
+
+
+def load_specific_case_aliases() -> dict[str, tuple[str, str]]:
+    return {
+        case_name_for_gradient_profile(run.name, gradient_profile): (
+            run.name,
+            gradient_profile,
+        )
+        for run in SANDWICH_RUNS
+        for gradient_profile in GRADIENT_PROFILES
+    }
+
+
+def case_choices() -> tuple[str, ...]:
+    base_cases = tuple(run.name for run in SANDWICH_RUNS)
+    load_specific_cases = tuple(sorted(load_specific_case_aliases()))
+    return base_cases + load_specific_cases
+
+
 def main() -> None:
     args = parse_args()
     runs = prepare_runs(args)
@@ -75,9 +96,12 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--case",
-        choices=[run.name for run in SANDWICH_RUNS],
+        choices=case_choices(),
         action="append",
-        help="Run only the selected case. Can be passed more than once.",
+        help=(
+            "Run only the selected case or load-specific scenario. "
+            "Can be passed more than once."
+        ),
     )
     parser.add_argument(
         "--iterations",
@@ -130,13 +154,11 @@ def prepare_runs(args: argparse.Namespace) -> tuple[SandwichRun, ...]:
         if not (0 < args.gradient_relaxation <= 1):
             raise SystemExit("--gradient-relaxation must be in the interval (0, 1].")
 
-    runs: Iterable[SandwichRun] = SANDWICH_RUNS
-    if args.case:
-        selected_names = set(args.case)
-        runs = [run for run in runs if run.name in selected_names]
-
+    runs_by_name = {run.name: run for run in SANDWICH_RUNS}
+    selected_cases = resolve_case_selection(args.case, args.gradient_profile)
     prepared = []
-    for run in runs:
+    for run_name, gradient_profile in selected_cases:
+        run = runs_by_name[run_name]
         replacements = {}
         if args.iterations is not None:
             replacements["iterations"] = args.iterations
@@ -151,11 +173,11 @@ def prepare_runs(args: argparse.Namespace) -> tuple[SandwichRun, ...]:
             )
         if args.gradient_relaxation is not None:
             replacements["gradient_relaxation"] = args.gradient_relaxation
-        if args.gradient_profile is not None:
-            replacements["gradient_profile"] = args.gradient_profile
-            replacements[
-                "name"
-            ] = f"{run.name}_{LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE[args.gradient_profile]}"
+        if gradient_profile is not None:
+            replacements["gradient_profile"] = gradient_profile
+            replacements["name"] = case_name_for_gradient_profile(
+                run.name, gradient_profile
+            )
         if args.enforce_overlap_continuity is not None:
             replacements["enforce_overlap_continuity"] = args.enforce_overlap_continuity
         prepared.append(dataclasses.replace(run, **replacements))
@@ -163,6 +185,31 @@ def prepare_runs(args: argparse.Namespace) -> tuple[SandwichRun, ...]:
     if not prepared:
         raise SystemExit("No sandwich cases selected.")
     return tuple(prepared)
+
+
+def resolve_case_selection(
+    case_names: Iterable[str] | None, gradient_profile: str | None
+) -> tuple[tuple[str, str | None], ...]:
+    if not case_names:
+        return tuple((run.name, gradient_profile) for run in SANDWICH_RUNS)
+
+    aliases = load_specific_case_aliases()
+    selected_cases = []
+    for case_name in case_names:
+        if case_name not in aliases:
+            selected_cases.append((case_name, gradient_profile))
+            continue
+
+        base_case_name, case_gradient_profile = aliases[case_name]
+        if gradient_profile is not None and gradient_profile != case_gradient_profile:
+            raise SystemExit(
+                f"--case {case_name!r} implies gradient profile "
+                f"{case_gradient_profile!r}, but --gradient-profile "
+                f"{gradient_profile!r} was requested."
+            )
+        selected_cases.append((base_case_name, case_gradient_profile))
+
+    return tuple(selected_cases)
 
 
 def run_case(

--- a/scripts/run_sandwich_integration.py
+++ b/scripts/run_sandwich_integration.py
@@ -27,6 +27,8 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from sandwich_numerical.integration import (
+    GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
+    GRADIENT_PROFILE_SINE,
     GRADIENT_PROFILES,
     SANDWICH_RUNS,
     SandwichRun,
@@ -39,6 +41,10 @@ from sandwich_numerical.integration import (
 FIGURE_WIDTH = 1120
 FIGURE_HEIGHT = 650
 DISPLACEMENT_CMAP = "bwr"
+LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE = {
+    GRADIENT_PROFILE_SINE: "load_sin",
+    GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN: "load_parabolic",
+}
 
 
 def main() -> None:
@@ -147,8 +153,9 @@ def prepare_runs(args: argparse.Namespace) -> tuple[SandwichRun, ...]:
             replacements["gradient_relaxation"] = args.gradient_relaxation
         if args.gradient_profile is not None:
             replacements["gradient_profile"] = args.gradient_profile
-            if args.gradient_profile != run.gradient_profile:
-                replacements["name"] = f"{run.name}_{args.gradient_profile}"
+            replacements[
+                "name"
+            ] = f"{run.name}_{LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE[args.gradient_profile]}"
         if args.enforce_overlap_continuity is not None:
             replacements["enforce_overlap_continuity"] = args.enforce_overlap_continuity
         prepared.append(dataclasses.replace(run, **replacements))

--- a/tests/test_sandwich_integration_e2e.py
+++ b/tests/test_sandwich_integration_e2e.py
@@ -124,6 +124,48 @@ def test_prepare_runs_adds_load_shape_to_name_for_explicit_profile(
 
 
 @pytest.mark.parametrize(
+    ("case_name", "expected_gradient_profile"),
+    [
+        ("grad_factors_1_1_1_load_sin", GRADIENT_PROFILE_SINE),
+        (
+            "grad_factors_1_1_1_load_parabolic",
+            GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
+        ),
+    ],
+)
+def test_prepare_runs_accepts_load_specific_case_names(
+    case_name: str, expected_gradient_profile: str
+) -> None:
+    args = argparse.Namespace(
+        case=[case_name],
+        iterations=None,
+        block_width=None,
+        gradient_relaxation=None,
+        gradient_profile=None,
+        enforce_overlap_continuity=None,
+    )
+
+    (run,) = prepare_runs(args)
+
+    assert run.name == case_name
+    assert run.gradient_profile == expected_gradient_profile
+
+
+def test_prepare_runs_rejects_mismatched_load_specific_case_profile() -> None:
+    args = argparse.Namespace(
+        case=["grad_factors_1_1_1_load_sin"],
+        iterations=None,
+        block_width=None,
+        gradient_relaxation=None,
+        gradient_profile=GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
+        enforce_overlap_continuity=None,
+    )
+
+    with pytest.raises(SystemExit, match="implies gradient profile"):
+        prepare_runs(args)
+
+
+@pytest.mark.parametrize(
     "data",
     [
         np.array([[-2.0, 0.0, 1.0]]),

--- a/tests/test_sandwich_integration_e2e.py
+++ b/tests/test_sandwich_integration_e2e.py
@@ -1,5 +1,6 @@
 """End-to-end regression checks for the scripted Sandwich integration runs."""
 
+import argparse
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -8,6 +9,7 @@ import pandas as pd
 import pytest
 
 from sandwich_numerical.integration import (
+    GRADIENT_PROFILE_SINE,
     GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
     SANDWICH_RUNS,
     SandwichRun,
@@ -21,6 +23,7 @@ from scripts.run_sandwich_integration import (
     layer_boundary_x2,
     make_displacement_norm,
     make_heatmap_figure,
+    prepare_runs,
 )
 
 
@@ -91,6 +94,33 @@ def test_parabolic_zero_mean_gradient_profile_matches_formula() -> None:
         full_thickness**3 / 12 - full_thickness * full_thickness**2 / 12
     )
     assert analytic_integral == pytest.approx(0.0, abs=1e-15)
+
+
+@pytest.mark.parametrize(
+    ("gradient_profile", "expected_name"),
+    [
+        (GRADIENT_PROFILE_SINE, "grad_factors_1_1_1_load_sin"),
+        (
+            GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
+            "grad_factors_1_1_1_load_parabolic",
+        ),
+    ],
+)
+def test_prepare_runs_adds_load_shape_to_name_for_explicit_profile(
+    gradient_profile: str, expected_name: str
+) -> None:
+    args = argparse.Namespace(
+        case=["grad_factors_1_1_1"],
+        iterations=None,
+        block_width=None,
+        gradient_relaxation=None,
+        gradient_profile=gradient_profile,
+        enforce_overlap_continuity=None,
+    )
+
+    (run,) = prepare_runs(args)
+
+    assert run.name == expected_name
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

Added a GitHub Actions workflow that generates Sandwich integration artifacts after a pull request is merged into `master`.

The workflow runs the six requested scenarios as a matrix:

- `(1, 1, 1)` with `sin`
- `(1, 1, 1)` with `parabolic`
- `(1, 1000, 1)` with `sin`
- `(1, 1000, 1)` with `parabolic`
- `(1000, 1, 1000, 1, 1000)` with `sin`
- `(1000, 1, 1000, 1, 1000)` with `parabolic`

Each scenario uploads its generated files as a separate GitHub Actions artifact with `retention-days: 30`.

## Validation

- Parsed the workflow YAML with Ruby's YAML loader.
- Ran a smoke scenario through `scripts/run_sandwich_integration.py` using `--iterations 0`, `--block-width 5`, and `--csv-only` to verify the selected case/profile path works.