### PR TITLE
[codex] add FEM sandwich solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# Pyright
+pyrightconfig.json
+
 # Pyre type checker
 .pyre/
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1494,6 +1494,104 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "scikit-fem"
+version = "12.0.2"
+description = "Simple finite element assemblers"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "scikit_fem-12.0.2-py3-none-any.whl", hash = "sha256:34cd891f80072c0c1eb759a2371e82f0eeec91ff7c08acab96d27b6edbbe1b05"},
+    {file = "scikit_fem-12.0.2.tar.gz", hash = "sha256:0a38764cdb93411c5a994451c22c1da07808ebabf920f462c6253f78f5703f8a"},
+]
+
+[package.dependencies]
+numpy = "*"
+scipy = "*"
+
+[package.extras]
+all = ["matplotlib", "meshio"]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+description = "Fundamental algorithms for scientific computing in Python"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec"},
+    {file = "scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696"},
+    {file = "scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee"},
+    {file = "scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd"},
+    {file = "scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c"},
+    {file = "scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4"},
+    {file = "scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444"},
+    {file = "scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082"},
+    {file = "scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff"},
+    {file = "scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b"},
+    {file = "scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21"},
+    {file = "scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458"},
+    {file = "scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb"},
+    {file = "scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea"},
+    {file = "scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87"},
+    {file = "scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b"},
+    {file = "scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6"},
+    {file = "scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464"},
+    {file = "scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950"},
+    {file = "scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369"},
+    {file = "scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448"},
+    {file = "scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6"},
+    {file = "scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e"},
+    {file = "scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475"},
+    {file = "scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50"},
+    {file = "scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca"},
+    {file = "scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c"},
+    {file = "scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866"},
+    {file = "scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350"},
+    {file = "scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118"},
+    {file = "scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068"},
+    {file = "scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118"},
+    {file = "scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19"},
+    {file = "scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca"},
+    {file = "scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad"},
+    {file = "scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a"},
+    {file = "scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4"},
+    {file = "scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2"},
+    {file = "scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484"},
+    {file = "scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21"},
+    {file = "scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0"},
+]
+
+[package.dependencies]
+numpy = ">=1.26.4,<2.7"
+
+[package.extras]
+dev = ["click (<8.3.0)", "cython-lint (>=0.12.2)", "mypy (==1.10.0)", "pycodestyle", "ruff (>=0.12.0)", "spin", "types-psutil", "typing_extensions"]
+doc = ["intersphinx_registry", "jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.19.1)", "jupytext", "linkify-it-py", "matplotlib (>=3.5)", "myst-nb (>=1.2.0)", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0,<8.2.0)", "sphinx-copybutton", "sphinx-design (>=0.4.0)", "tabulate"]
+test = ["Cython", "array-api-strict (>=2.3.1)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja ; sys_platform != \"emscripten\"", "pooch", "pytest (>=8.0.0)", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1736,4 +1834,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "d8707b5306b33ff60f68faa24e0ae9b301b536bb852952633d0f7895ec05339d"
+content-hash = "d7b12f73f48497d0c873624198e067cc91c801c15fc2cdf73c32f8a24d0af7eb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ numpy = "^1.21.0"
 pandas = "^1.3.0"
 plotly = "^5.0.0"
 matplotlib = "^3.10.9"
+scikit-fem = "^12.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"
@@ -50,7 +51,7 @@ warn_unused_configs = true
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = ["pandas", "pandas.*", "plotly.*"]
+module = ["pandas", "pandas.*", "plotly.*", "skfem", "skfem.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/sandwich_numerical/artifacts.py
+++ b/sandwich_numerical/artifacts.py
@@ -1,0 +1,414 @@
+"""Shared CLI and plotting helpers for Sandwich integration artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import os
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Protocol
+
+os.environ.setdefault("MPLCONFIGDIR", "/tmp/sandwich_matplotlib_config")
+os.environ.setdefault("XDG_CACHE_HOME", "/tmp/sandwich_cache")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+from matplotlib.axes import Axes  # noqa: E402
+from matplotlib.colors import Normalize, TwoSlopeNorm  # noqa: E402
+from matplotlib.figure import Figure  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from sandwich_numerical.integration import (  # noqa: E402
+    GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
+    GRADIENT_PROFILE_SINE,
+    GRADIENT_PROFILES,
+    SANDWICH_RUNS,
+    ProgressCallback,
+    SandwichRun,
+    SandwichSolution,
+    layer_boundary_rows,
+    layer_boundary_x2,
+    write_solution_csvs,
+)
+
+
+class CaseSolver(Protocol):
+    def __call__(
+        self,
+        run: SandwichRun,
+        progress_callback: ProgressCallback | None = None,
+    ) -> SandwichSolution:
+        ...
+
+
+FIGURE_WIDTH = 1120
+FIGURE_HEIGHT = 650
+DISPLACEMENT_CMAP = "bwr"
+LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE = {
+    GRADIENT_PROFILE_SINE: "load_sin",
+    GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN: "load_parabolic",
+}
+
+
+def case_name_for_gradient_profile(case_name: str, gradient_profile: str) -> str:
+    return f"{case_name}_{LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE[gradient_profile]}"
+
+
+def load_specific_case_aliases() -> dict[str, tuple[str, str]]:
+    return {
+        case_name_for_gradient_profile(run.name, gradient_profile): (
+            run.name,
+            gradient_profile,
+        )
+        for run in SANDWICH_RUNS
+        for gradient_profile in GRADIENT_PROFILES
+    }
+
+
+def case_choices() -> tuple[str, ...]:
+    base_cases = tuple(run.name for run in SANDWICH_RUNS)
+    load_specific_cases = tuple(sorted(load_specific_case_aliases()))
+    return base_cases + load_specific_cases
+
+
+def main(
+    solve_case: CaseSolver,
+    default_output_dir: Path,
+    parser_description: str,
+) -> None:
+    args = parse_args(default_output_dir, parser_description)
+    runs = prepare_runs(args)
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Writing artifacts to {output_dir}")
+    print(f"Configured sandwiches: {len(runs)}")
+
+    for index, run in enumerate(runs, start=1):
+        run_case(
+            run,
+            index,
+            len(runs),
+            output_dir,
+            solve_case=solve_case,
+            write_figures=not args.csv_only,
+        )
+
+    print("Done.")
+
+
+def parse_args(default_output_dir: Path, parser_description: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=parser_description)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=default_output_dir,
+        help="Directory for generated CSV and PNG files.",
+    )
+    parser.add_argument(
+        "--case",
+        choices=case_choices(),
+        action="append",
+        help=(
+            "Run only the selected case or load-specific scenario. "
+            "Can be passed more than once."
+        ),
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        help="Override iteration count for all selected sandwiches.",
+    )
+    parser.add_argument(
+        "--block-width",
+        type=int,
+        help="Override block width for all selected sandwiches; useful for smoke runs.",
+    )
+    parser.add_argument(
+        "--gradient-relaxation",
+        type=float,
+        help="Under-relaxation for copied interface gradients.",
+    )
+    parser.add_argument(
+        "--gradient-profile",
+        choices=GRADIENT_PROFILES,
+        help="Override the boundary gradient profile for selected sandwiches.",
+    )
+    overlap_group = parser.add_mutually_exclusive_group()
+    overlap_group.add_argument(
+        "--enforce-overlap-continuity",
+        dest="enforce_overlap_continuity",
+        action="store_true",
+        default=None,
+        help="Average duplicate real/ghost rows shared by adjacent blocks.",
+    )
+    overlap_group.add_argument(
+        "--no-enforce-overlap-continuity",
+        dest="enforce_overlap_continuity",
+        action="store_false",
+        help="Disable averaging of duplicate real/ghost rows.",
+    )
+    parser.add_argument(
+        "--csv-only",
+        action="store_true",
+        help="Write CSV data without PNG figures.",
+    )
+    return parser.parse_args()
+
+
+def prepare_runs(args: argparse.Namespace) -> tuple[SandwichRun, ...]:
+    if args.iterations is not None and args.iterations < 0:
+        raise SystemExit("--iterations must be non-negative.")
+    if args.block_width is not None and args.block_width < 2:
+        raise SystemExit("--block-width must be at least 2.")
+    if args.gradient_relaxation is not None:
+        if not (0 < args.gradient_relaxation <= 1):
+            raise SystemExit("--gradient-relaxation must be in the interval (0, 1].")
+
+    runs_by_name = {run.name: run for run in SANDWICH_RUNS}
+    selected_cases = resolve_case_selection(args.case, args.gradient_profile)
+    prepared = []
+    for run_name, gradient_profile in selected_cases:
+        run = runs_by_name[run_name]
+        replacements = {}
+        if args.iterations is not None:
+            replacements["iterations"] = args.iterations
+            interval = max(1, min(run.residual_every, args.iterations))
+            replacements["residual_every"] = interval
+            replacements["progress_every"] = interval
+        if args.block_width is not None:
+            replacements["block_width"] = args.block_width
+            replacements["heatmap_columns"] = min(run.heatmap_columns, args.block_width)
+            replacements["detail_heatmap_columns"] = min(
+                run.detail_heatmap_columns, args.block_width
+            )
+        if args.gradient_relaxation is not None:
+            replacements["gradient_relaxation"] = args.gradient_relaxation
+        if gradient_profile is not None:
+            replacements["gradient_profile"] = gradient_profile
+            replacements["name"] = case_name_for_gradient_profile(
+                run.name, gradient_profile
+            )
+        if args.enforce_overlap_continuity is not None:
+            replacements["enforce_overlap_continuity"] = args.enforce_overlap_continuity
+        prepared.append(dataclasses.replace(run, **replacements))
+
+    if not prepared:
+        raise SystemExit("No sandwich cases selected.")
+    return tuple(prepared)
+
+
+def resolve_case_selection(
+    case_names: Iterable[str] | None, gradient_profile: str | None
+) -> tuple[tuple[str, str | None], ...]:
+    if not case_names:
+        return tuple((run.name, gradient_profile) for run in SANDWICH_RUNS)
+
+    aliases = load_specific_case_aliases()
+    selected_cases = []
+    for case_name in case_names:
+        if case_name not in aliases:
+            selected_cases.append((case_name, gradient_profile))
+            continue
+
+        base_case_name, case_gradient_profile = aliases[case_name]
+        if gradient_profile is not None and gradient_profile != case_gradient_profile:
+            raise SystemExit(
+                f"--case {case_name!r} implies gradient profile "
+                f"{case_gradient_profile!r}, but --gradient-profile "
+                f"{gradient_profile!r} was requested."
+            )
+        selected_cases.append((base_case_name, case_gradient_profile))
+
+    return tuple(selected_cases)
+
+
+def run_case(
+    run: SandwichRun,
+    case_index: int,
+    case_count: int,
+    output_dir: Path,
+    solve_case: CaseSolver,
+    write_figures: bool = True,
+) -> None:
+    case_dir = output_dir / run.name
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    print("")
+    print(f"[{case_index}/{case_count}] {run.name}")
+    print(
+        "  block_size="
+        f"({run.block_height}, {run.block_width}), "
+        f"grid_step={run.grid_step}, "
+        f"grad_factors={run.grad_factors}, "
+        f"gradient_profile={run.gradient_profile}, "
+        f"gradient_relaxation={run.gradient_relaxation}, "
+        f"enforce_overlap_continuity={run.enforce_overlap_continuity}, "
+        f"iterations={run.iterations}"
+    )
+
+    started_at = time.perf_counter()
+
+    solution = solve_case(
+        run,
+        progress_callback=lambda iteration, residual: report_progress(
+            iteration, residual, run.iterations, started_at
+        ),
+    )
+
+    write_solution_csvs(case_dir, run, solution)
+    if write_figures:
+        write_solution_figures(case_dir, run, solution)
+
+    print(f"  wrote {case_dir}")
+
+
+def report_progress(
+    iteration: int, residual: float | None, total_iterations: int, started_at: float
+) -> None:
+    elapsed = time.perf_counter() - started_at
+    if residual is None:
+        print(f"  iter {iteration:>6}/{total_iterations}: {elapsed:6.1f}s")
+    else:
+        print(
+            f"  iter {iteration:>6}/{total_iterations}: "
+            f"residual={residual:.6e}, elapsed={elapsed:6.1f}s"
+        )
+
+
+def write_solution_figures(
+    case_dir: Path, run: SandwichRun, solution: SandwichSolution
+) -> None:
+    displacement = solution.displacement.drop(
+        columns=["x2_mesh_id", "x2_bottom", "x2_top"]
+    ).to_numpy()
+    heatmap_columns = min(run.heatmap_columns, displacement.shape[1])
+    detail_columns = min(run.detail_heatmap_columns, displacement.shape[1])
+    write_figure_png(
+        make_heatmap_figure(
+            displacement[:, :heatmap_columns],
+            f"Displacement {run.name}: first {heatmap_columns} columns",
+            layer_boundary_rows(run),
+        ),
+        case_dir / "displacement_heatmap.png",
+    )
+    write_figure_png(
+        make_heatmap_figure(
+            displacement[:, :detail_columns],
+            f"Displacement {run.name}: first {detail_columns} columns",
+            layer_boundary_rows(run),
+        ),
+        case_dir / "displacement_detail_heatmap.png",
+    )
+    write_figure_png(
+        make_samples_figure(
+            solution.samples,
+            f"Samples {run.name}",
+            layer_boundary_x2(run),
+        ),
+        case_dir / "samples.png",
+    )
+    write_figure_png(
+        make_residuals_figure(solution.residuals, f"Residual {run.name}"),
+        case_dir / "residuals.png",
+    )
+
+
+def make_heatmap_figure(
+    data: np.ndarray, title: str, layer_boundaries: np.ndarray | None = None
+) -> Figure:
+    fig, ax = plt.subplots(figsize=(11.2, 6.5))
+    image = ax.imshow(
+        data,
+        aspect="auto",
+        cmap=DISPLACEMENT_CMAP,
+        norm=make_displacement_norm(data),
+        origin="lower",
+    )
+    ax.set_title(title)
+    ax.set_xlabel("x1 column")
+    ax.set_ylabel("x2 row")
+    add_horizontal_layer_boundaries(ax, layer_boundaries, data.shape[0])
+    fig.colorbar(image, ax=ax, label="displacement")
+    return fig
+
+
+def make_samples_figure(
+    samples: pd.DataFrame, title: str, layer_boundaries: np.ndarray | None = None
+) -> Figure:
+    fig, ax = plt.subplots(figsize=(11.2, 6.5))
+    for column in samples.columns:
+        if column == "x2":
+            continue
+        ax.plot(samples["x2"], samples[column], label=column)
+    add_vertical_layer_boundaries(ax, layer_boundaries)
+    ax.set_title(title)
+    ax.set_xlabel("x2")
+    ax.set_ylabel("displacement")
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+    return fig
+
+
+def add_horizontal_layer_boundaries(
+    ax: Axes, layer_boundaries: np.ndarray | None, row_count: int
+) -> None:
+    if layer_boundaries is None:
+        return
+    for boundary in layer_boundaries:
+        if 0 < boundary < row_count - 1:
+            ax.axhline(
+                boundary, color="black", linestyle="--", linewidth=0.8, alpha=0.5
+            )
+
+
+def add_vertical_layer_boundaries(
+    ax: Axes, layer_boundaries: np.ndarray | None
+) -> None:
+    if layer_boundaries is None:
+        return
+    for index, boundary in enumerate(layer_boundaries):
+        ax.axvline(
+            boundary,
+            color="black",
+            linestyle="--",
+            linewidth=0.8,
+            alpha=0.5,
+            label="layer boundary" if index == 0 else "_nolegend_",
+        )
+
+
+def make_residuals_figure(residuals: pd.DataFrame, title: str) -> Figure:
+    fig, ax = plt.subplots(figsize=(11.2, 6.5))
+    ax.plot(residuals["iteration"], residuals["residual"])
+    ax.set_title(title)
+    ax.set_xlabel("iteration")
+    ax.set_ylabel("residual")
+    ax.grid(True, alpha=0.3)
+    return fig
+
+
+def make_displacement_norm(data: np.ndarray) -> Normalize | None:
+    finite = data[np.isfinite(data)]
+    if finite.size == 0:
+        return None
+    min_value = float(finite.min())
+    max_value = float(finite.max())
+    limit = max(abs(min_value), abs(max_value))
+    if limit == 0:
+        limit = 1.0
+    return TwoSlopeNorm(vmin=-limit, vcenter=0, vmax=limit)
+
+
+def write_figure_png(
+    fig: Figure, path: Path, width: int = FIGURE_WIDTH, height: int = FIGURE_HEIGHT
+) -> None:
+    fig.set_size_inches(width / 100, height / 100)
+    fig.tight_layout()
+    fig.savefig(path, dpi=160)
+    plt.close(fig)

--- a/sandwich_numerical/fdm/__init__.py
+++ b/sandwich_numerical/fdm/__init__.py
@@ -1,15 +1,8 @@
 """Finite-difference implementation of the Sandwich numerical method."""
 
-from .sandwich import (
+from .sandwich import (  # noqa: F401
     Sandwich,
     set_boundary_conditions_bottom_block,
     set_boundary_conditions_middle_block,
     set_boundary_conditions_top_block,
 )
-
-__all__ = [
-    "Sandwich",
-    "set_boundary_conditions_bottom_block",
-    "set_boundary_conditions_middle_block",
-    "set_boundary_conditions_top_block",
-]

--- a/sandwich_numerical/fdm/integration.py
+++ b/sandwich_numerical/fdm/integration.py
@@ -1,95 +1,18 @@
-"""Reusable Sandwich integration scenario runner."""
+"""Reusable FDM Sandwich integration scenario runner."""
 
 from __future__ import annotations
 
-import dataclasses
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Callable
-
-import numpy as np
 import pandas as pd
 
+from sandwich_numerical.integration import (
+    ProgressCallback,
+    SandwichRun,
+    SandwichSolution,
+    build_gradient_vector,
+    solution_from_displacement,
+)
+
 from .sandwich import Sandwich
-
-
-@dataclass(frozen=True)
-class SandwichRun:
-    name: str
-    block_height: int
-    block_width: int
-    grid_step: float
-    grad_factors: tuple[float, ...]
-    iterations: int
-    residual_every: int
-    progress_every: int
-    heatmap_columns: int
-    detail_heatmap_columns: int
-    sample_x1_positions: tuple[float, ...]
-    gradient_profile: str = "sine"
-    gradient_relaxation: float = 1.0
-    enforce_overlap_continuity: bool = True
-
-
-@dataclass(frozen=True)
-class SandwichSolution:
-    residuals: pd.DataFrame
-    samples: pd.DataFrame
-    displacement: pd.DataFrame
-
-
-ProgressCallback = Callable[[int, float | None], None]
-
-GRADIENT_PROFILE_SINE = "sine"
-GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN = "parabolic_zero_mean"
-GRADIENT_PROFILES = (
-    GRADIENT_PROFILE_SINE,
-    GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
-)
-
-
-SANDWICH_RUNS: tuple[SandwichRun, ...] = (
-    SandwichRun(
-        name="grad_factors_1_1_1",
-        block_height=21,
-        block_width=3000,
-        grid_step=0.005,
-        grad_factors=(1.0, 1.0, 1.0),
-        iterations=10_000,
-        residual_every=1_000,
-        progress_every=1_000,
-        heatmap_columns=1_000,
-        detail_heatmap_columns=100,
-        sample_x1_positions=(0.0, 0.2, 0.4, 1.0),
-    ),
-    SandwichRun(
-        name="grad_factors_1_1000_1",
-        block_height=21,
-        block_width=3000,
-        grid_step=0.005,
-        grad_factors=(1.0, 1_000.0, 1.0),
-        iterations=10_000,
-        residual_every=1_000,
-        progress_every=1_000,
-        heatmap_columns=1_000,
-        detail_heatmap_columns=100,
-        sample_x1_positions=(0.0, 0.2, 0.4, 1.0),
-    ),
-    SandwichRun(
-        name="grad_factors_1000_1_1000_1_1000",
-        block_height=21,
-        block_width=3000,
-        grid_step=0.005,
-        grad_factors=(1_000.0, 1.0, 1_000.0, 1.0, 1_000.0),
-        iterations=10_000,
-        residual_every=500,
-        progress_every=500,
-        heatmap_columns=1_000,
-        detail_heatmap_columns=100,
-        sample_x1_positions=(0.0, 0.2, 0.4, 1.0),
-        gradient_relaxation=0.001,
-    ),
-)
 
 
 def solve_case(
@@ -119,16 +42,8 @@ def solve_case(
         if should_report_progress and progress_callback is not None:
             progress_callback(iteration, residual)
 
-    displacement = mesh.get_displacement_array()
     residuals = pd.DataFrame(residual_rows)
-    samples = samples_data_to_df(run, displacement)
-    displacement_data = displacement_data_to_df(run, displacement)
-
-    return SandwichSolution(
-        residuals=residuals,
-        samples=samples,
-        displacement=displacement_data,
-    )
+    return solution_from_displacement(run, residuals, mesh.get_displacement_array())
 
 
 def create_sandwich(run: SandwichRun) -> Sandwich:
@@ -141,62 +56,3 @@ def create_sandwich(run: SandwichRun) -> Sandwich:
         gradient_relaxation=run.gradient_relaxation,
         enforce_overlap_continuity=run.enforce_overlap_continuity,
     )
-
-
-def build_gradient_vector(run: SandwichRun) -> np.ndarray:
-    mesh_height = run.block_height * len(run.grad_factors)
-
-    if run.gradient_profile == GRADIENT_PROFILE_SINE:
-        gradient = np.sin((2 * np.pi) / (mesh_height - 1) * np.arange(mesh_height))
-    elif run.gradient_profile == GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN:
-        full_thickness = (mesh_height - 1) * run.grid_step
-        x = np.linspace(-full_thickness / 2, full_thickness / 2, mesh_height)
-        gradient = x**2 - full_thickness**2 / 12
-    else:
-        raise ValueError(f"Unsupported gradient profile: {run.gradient_profile}")
-
-    return np.asarray(gradient, dtype=float)
-
-
-def samples_data_to_df(run: SandwichRun, displacement: np.ndarray) -> pd.DataFrame:
-    columns: dict[str, np.ndarray] = {
-        "x2": np.arange(displacement.shape[0]) * run.grid_step
-    }
-    for x1_position in run.sample_x1_positions:
-        column_index = int(round(x1_position / run.grid_step))
-        if column_index >= displacement.shape[1]:
-            print(
-                f"  skipping sample x1={x1_position:g}: "
-                f"column {column_index} is outside width {displacement.shape[1]}"
-            )
-            continue
-        columns[f"x1={x1_position:.1f}"] = displacement[:, column_index]
-    return pd.DataFrame(columns)
-
-
-def displacement_data_to_df(run: SandwichRun, displacement: np.ndarray) -> pd.DataFrame:
-    x2_mesh_id = np.arange(displacement.shape[0])
-    result: dict[str, np.ndarray] = {
-        "x2_mesh_id": x2_mesh_id,
-        "x2_bottom": x2_mesh_id * run.grid_step,
-        "x2_top": (x2_mesh_id + 1) * run.grid_step,
-    }
-
-    for index in range(displacement.shape[1]):
-        result[f"x1={index * run.grid_step:.4f}"] = displacement[:, index]
-    return pd.DataFrame(result)
-
-
-def parameters_data_to_df(run: SandwichRun) -> pd.DataFrame:
-    result = pd.DataFrame([dataclasses.asdict(run)])
-    result["grad_factors"] = result["grad_factors"].astype(str)
-    return result
-
-
-def write_solution_csvs(
-    case_dir: Path, run: SandwichRun, solution: SandwichSolution
-) -> None:
-    solution.residuals.to_csv(case_dir / "residuals.csv", index=False)
-    solution.samples.to_csv(case_dir / "samples.csv", index=False)
-    solution.displacement.to_csv(case_dir / "displacement.csv", index=False)
-    parameters_data_to_df(run).to_csv(case_dir / "parameters.csv", index=False)

--- a/sandwich_numerical/fdm/solver/__init__.py
+++ b/sandwich_numerical/fdm/solver/__init__.py
@@ -1,13 +1,5 @@
 """Finite-difference solver primitives."""
 
-from .laplace import set_laplace_update
-from .mesh_block import BoundaryType, MeshBlock
-from .mesh_utils import copy_boundary_gradients, copy_boundary_values
-
-__all__ = [
-    "BoundaryType",
-    "MeshBlock",
-    "copy_boundary_gradients",
-    "copy_boundary_values",
-    "set_laplace_update",
-]
+from .laplace import set_laplace_update  # noqa: F401
+from .mesh_block import BoundaryType, MeshBlock  # noqa: F401
+from .mesh_utils import copy_boundary_gradients, copy_boundary_values  # noqa: F401

--- a/sandwich_numerical/fem/__init__.py
+++ b/sandwich_numerical/fem/__init__.py
@@ -1,0 +1,1 @@
+"""Finite-element implementation of the Sandwich numerical method."""

--- a/sandwich_numerical/fem/integration.py
+++ b/sandwich_numerical/fem/integration.py
@@ -1,0 +1,166 @@
+"""Reusable FEM Sandwich integration scenario runner."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from skfem import (
+    Basis,
+    BilinearForm,
+    ElementQuad1,
+    FacetBasis,
+    LinearForm,
+    MeshQuad,
+    asm,
+    condense,
+    solve,
+)
+from skfem.helpers import dot, grad
+
+from sandwich_numerical.integration import (
+    ProgressCallback,
+    SandwichRun,
+    SandwichSolution,
+    build_gradient_vector,
+    layer_boundary_x2,
+    sample_x1_coordinates,
+    sample_x2_coordinates,
+    solution_from_displacement,
+)
+
+
+COORDINATE_KEY_DECIMALS = 12
+
+
+@BilinearForm
+def stiffness(u: Any, v: Any, w: dict[str, Any]) -> Any:
+    return w["coefficient"] * dot(grad(u), grad(v))
+
+
+@LinearForm
+def left_neumann(v: Any, w: dict[str, Any]) -> Any:
+    return -w["coefficient"] * w["left_gradient"] * v
+
+
+def solve_case(
+    run: SandwichRun, progress_callback: ProgressCallback | None = None
+) -> SandwichSolution:
+    displacement, residual = solve_displacement(run, build_gradient_vector(run))
+    if progress_callback is not None:
+        progress_callback(0, residual)
+
+    residuals = pd.DataFrame([{"iteration": 0, "residual": residual}])
+    return solution_from_displacement(run, residuals, displacement)
+
+
+def solve_displacement(
+    run: SandwichRun, gradient_vector: np.ndarray
+) -> tuple[np.ndarray, float]:
+    basis = Basis(create_rectangular_mesh(run), ElementQuad1())
+
+    A = assemble_stiffness(run, basis)
+    b = assemble_left_boundary_load(run, basis, gradient_vector)
+    right_dofs = right_boundary_dofs(run, basis)
+
+    solution = solve(*condense(A, b, D=right_dofs))
+    residual = algebraic_residual_norm(A, b, solution, constrained_dofs=right_dofs)
+    return sample_solution_on_grid(run, basis, solution), residual
+
+
+def create_rectangular_mesh(run: SandwichRun) -> MeshQuad:
+    x2 = np.concatenate((sample_x2_coordinates(run), layer_boundary_x2(run)))
+    return MeshQuad.init_tensor(sample_x1_coordinates(run), np.unique(np.sort(x2)))
+
+
+def assemble_stiffness(run: SandwichRun, basis: Basis) -> Any:
+    return asm(
+        stiffness,
+        basis,
+        coefficient=layer_coefficient(run, basis.global_coordinates()[1]),
+    )
+
+
+def assemble_left_boundary_load(
+    run: SandwichRun, basis: Basis, gradient_vector: np.ndarray
+) -> np.ndarray:
+    left_basis = FacetBasis(
+        basis.mesh,
+        basis.elem,
+        facets=basis.mesh.facets_satisfying(
+            lambda x: np.isclose(x[0], 0.0),
+            boundaries_only=True,
+        ),
+    )
+    x2 = left_basis.global_coordinates()[1]
+    return np.asarray(
+        asm(
+            left_neumann,
+            left_basis,
+            coefficient=layer_coefficient(run, x2),
+            left_gradient=left_boundary_gradient(run, gradient_vector, x2),
+        ),
+        dtype=float,
+    )
+
+
+def right_boundary_dofs(run: SandwichRun, basis: Basis) -> np.ndarray:
+    x_right = (run.block_width - 1) * run.grid_step
+    return np.asarray(
+        basis.get_dofs(lambda x: np.isclose(x[0], x_right)).flatten(),
+        dtype=np.int64,
+    )
+
+
+def layer_coefficient(run: SandwichRun, x2: np.ndarray) -> np.ndarray:
+    boundaries = layer_boundary_x2(run)
+    layer_ids = np.searchsorted(boundaries, x2, side="right")
+    factors = np.asarray(run.grad_factors, dtype=float)
+    return 1.0 / factors[layer_ids]
+
+
+def left_boundary_gradient(
+    run: SandwichRun, gradient_vector: np.ndarray, x2: np.ndarray
+) -> np.ndarray:
+    return np.interp(x2, sample_x2_coordinates(run), gradient_vector)
+
+
+def algebraic_residual_norm(
+    A: Any,
+    b: np.ndarray,
+    solution: np.ndarray,
+    constrained_dofs: np.ndarray,
+) -> float:
+    residual = A @ solution - b
+    all_dofs = np.arange(A.shape[0])
+    free_dofs = np.setdiff1d(all_dofs, constrained_dofs, assume_unique=False)
+    return float(np.linalg.norm(residual[free_dofs]))
+
+
+def sample_solution_on_grid(
+    run: SandwichRun, basis: Basis, solution: np.ndarray
+) -> np.ndarray:
+    values_by_coordinate = {
+        coordinate_key(x1, x2): value
+        for (x1, x2), value in zip(basis.doflocs.T, solution)
+    }
+
+    x1_coordinates = sample_x1_coordinates(run)
+    x2_coordinates = sample_x2_coordinates(run)
+    displacement = np.empty((x2_coordinates.size, x1_coordinates.size), dtype=float)
+
+    for row_index, x2 in enumerate(x2_coordinates):
+        for column_index, x1 in enumerate(x1_coordinates):
+            displacement[row_index, column_index] = values_by_coordinate[
+                coordinate_key(x1, x2)
+            ]
+
+    return displacement
+
+
+def coordinate_key(x1: float, x2: float) -> tuple[float, float]:
+    return (
+        round(float(x1), COORDINATE_KEY_DECIMALS),
+        round(float(x2), COORDINATE_KEY_DECIMALS),
+    )

--- a/sandwich_numerical/integration.py
+++ b/sandwich_numerical/integration.py
@@ -1,0 +1,179 @@
+"""Shared Sandwich integration scenario and artifact helpers."""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class SandwichRun:
+    name: str
+    block_height: int
+    block_width: int
+    grid_step: float
+    grad_factors: tuple[float, ...]
+    iterations: int
+    residual_every: int
+    progress_every: int
+    heatmap_columns: int
+    detail_heatmap_columns: int
+    sample_x1_positions: tuple[float, ...]
+    gradient_profile: str = "sine"
+    gradient_relaxation: float = 1.0
+    enforce_overlap_continuity: bool = True
+
+
+@dataclass(frozen=True)
+class SandwichSolution:
+    residuals: pd.DataFrame
+    samples: pd.DataFrame
+    displacement: pd.DataFrame
+
+
+ProgressCallback = Callable[[int, float | None], None]
+
+GRADIENT_PROFILE_SINE = "sine"
+GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN = "parabolic_zero_mean"
+GRADIENT_PROFILES = (
+    GRADIENT_PROFILE_SINE,
+    GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
+)
+
+
+SANDWICH_RUNS: tuple[SandwichRun, ...] = (
+    SandwichRun(
+        name="grad_factors_1_1_1",
+        block_height=21,
+        block_width=3000,
+        grid_step=0.005,
+        grad_factors=(1.0, 1.0, 1.0),
+        iterations=10_000,
+        residual_every=1_000,
+        progress_every=1_000,
+        heatmap_columns=1_000,
+        detail_heatmap_columns=100,
+        sample_x1_positions=(0.0, 0.2, 0.4, 1.0),
+    ),
+    SandwichRun(
+        name="grad_factors_1_1000_1",
+        block_height=21,
+        block_width=3000,
+        grid_step=0.005,
+        grad_factors=(1.0, 1_000.0, 1.0),
+        iterations=10_000,
+        residual_every=1_000,
+        progress_every=1_000,
+        heatmap_columns=1_000,
+        detail_heatmap_columns=100,
+        sample_x1_positions=(0.0, 0.2, 0.4, 1.0),
+    ),
+    SandwichRun(
+        name="grad_factors_1000_1_1000_1_1000",
+        block_height=21,
+        block_width=3000,
+        grid_step=0.005,
+        grad_factors=(1_000.0, 1.0, 1_000.0, 1.0, 1_000.0),
+        iterations=10_000,
+        residual_every=500,
+        progress_every=500,
+        heatmap_columns=1_000,
+        detail_heatmap_columns=100,
+        sample_x1_positions=(0.0, 0.2, 0.4, 1.0),
+        gradient_relaxation=0.001,
+    ),
+)
+
+
+def mesh_height(run: SandwichRun) -> int:
+    return run.block_height * len(run.grad_factors)
+
+
+def sample_x1_coordinates(run: SandwichRun) -> np.ndarray:
+    return np.arange(run.block_width, dtype=float) * run.grid_step
+
+
+def sample_x2_coordinates(run: SandwichRun) -> np.ndarray:
+    return np.arange(mesh_height(run), dtype=float) * run.grid_step
+
+
+def layer_boundary_rows(run: SandwichRun) -> np.ndarray:
+    return np.arange(1, len(run.grad_factors), dtype=float) * run.block_height - 0.5
+
+
+def layer_boundary_x2(run: SandwichRun) -> np.ndarray:
+    return layer_boundary_rows(run) * run.grid_step
+
+
+def build_gradient_vector(run: SandwichRun) -> np.ndarray:
+    height = mesh_height(run)
+
+    if run.gradient_profile == GRADIENT_PROFILE_SINE:
+        gradient = np.sin((2 * np.pi) / (height - 1) * np.arange(height))
+    elif run.gradient_profile == GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN:
+        full_thickness = (height - 1) * run.grid_step
+        x = np.linspace(-full_thickness / 2, full_thickness / 2, height)
+        gradient = x**2 - full_thickness**2 / 12
+    else:
+        raise ValueError(f"Unsupported gradient profile: {run.gradient_profile}")
+
+    return np.asarray(gradient, dtype=float)
+
+
+def samples_data_to_df(run: SandwichRun, displacement: np.ndarray) -> pd.DataFrame:
+    columns: dict[str, np.ndarray] = {"x2": sample_x2_coordinates(run)}
+    for x1_position in run.sample_x1_positions:
+        column_index = int(round(x1_position / run.grid_step))
+        if column_index >= displacement.shape[1]:
+            print(
+                f"  skipping sample x1={x1_position:g}: "
+                f"column {column_index} is outside width {displacement.shape[1]}"
+            )
+            continue
+        columns[f"x1={x1_position:.1f}"] = displacement[:, column_index]
+    return pd.DataFrame(columns)
+
+
+def displacement_data_to_df(run: SandwichRun, displacement: np.ndarray) -> pd.DataFrame:
+    x2_mesh_id = np.arange(displacement.shape[0])
+    result: dict[str, np.ndarray] = {
+        "x2_mesh_id": x2_mesh_id,
+        "x2_bottom": x2_mesh_id * run.grid_step,
+        "x2_top": (x2_mesh_id + 1) * run.grid_step,
+    }
+
+    for index in range(displacement.shape[1]):
+        result[f"x1={index * run.grid_step:.4f}"] = displacement[:, index]
+    return pd.DataFrame(result)
+
+
+def parameters_data_to_df(run: SandwichRun) -> pd.DataFrame:
+    result = pd.DataFrame([dataclasses.asdict(run)])
+    result["grad_factors"] = result["grad_factors"].astype(str)
+    return result
+
+
+def solution_from_displacement(
+    run: SandwichRun,
+    residuals: pd.DataFrame,
+    displacement: np.ndarray,
+) -> SandwichSolution:
+    return SandwichSolution(
+        residuals=residuals,
+        samples=samples_data_to_df(run, displacement),
+        displacement=displacement_data_to_df(run, displacement),
+    )
+
+
+def write_solution_csvs(
+    case_dir: Path, run: SandwichRun, solution: SandwichSolution
+) -> None:
+    solution.residuals.to_csv(case_dir / "residuals.csv", index=False)
+    solution.samples.to_csv(case_dir / "samples.csv", index=False)
+    solution.displacement.to_csv(case_dir / "displacement.csv", index=False)
+    parameters_data_to_df(run).to_csv(case_dir / "parameters.csv", index=False)

--- a/scripts/fdm/run_sandwich_integration.py
+++ b/scripts/fdm/run_sandwich_integration.py
@@ -1,406 +1,76 @@
 #!/usr/bin/env python3
-"""Run the Sandwich integration scenarios and save reproducible artifacts."""
+"""Run the FDM Sandwich integration scenarios and save reproducible artifacts."""
 
 from __future__ import annotations
 
-import argparse
-import dataclasses
-import os
 import sys
-import time
 from pathlib import Path
-from typing import Iterable
-
-os.environ.setdefault("MPLCONFIGDIR", "/tmp/sandwich_matplotlib_config")
-os.environ.setdefault("XDG_CACHE_HOME", "/tmp/sandwich_cache")
-
-import matplotlib
-
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-from matplotlib.colors import TwoSlopeNorm
-import numpy as np
-import pandas as pd
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from sandwich_numerical.fdm.integration import (
-    GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
-    GRADIENT_PROFILE_SINE,
-    GRADIENT_PROFILES,
-    SANDWICH_RUNS,
-    SandwichRun,
-    SandwichSolution,
-    solve_case,
-    write_solution_csvs,
-)
+from sandwich_numerical import artifacts as _artifacts  # noqa: E402
+from sandwich_numerical.fdm.integration import solve_case  # noqa: E402
 
 
-FIGURE_WIDTH = 1120
-FIGURE_HEIGHT = 650
-DISPLACEMENT_CMAP = "bwr"
-LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE = {
-    GRADIENT_PROFILE_SINE: "load_sin",
-    GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN: "load_parabolic",
-}
+DISPLACEMENT_CMAP = _artifacts.DISPLACEMENT_CMAP
+FIGURE_HEIGHT = _artifacts.FIGURE_HEIGHT
+FIGURE_WIDTH = _artifacts.FIGURE_WIDTH
+add_horizontal_layer_boundaries = _artifacts.add_horizontal_layer_boundaries
+add_vertical_layer_boundaries = _artifacts.add_vertical_layer_boundaries
+case_choices = _artifacts.case_choices
+case_name_for_gradient_profile = _artifacts.case_name_for_gradient_profile
+layer_boundary_rows = _artifacts.layer_boundary_rows
+layer_boundary_x2 = _artifacts.layer_boundary_x2
+load_specific_case_aliases = _artifacts.load_specific_case_aliases
+make_displacement_norm = _artifacts.make_displacement_norm
+make_heatmap_figure = _artifacts.make_heatmap_figure
+make_residuals_figure = _artifacts.make_residuals_figure
+make_samples_figure = _artifacts.make_samples_figure
+prepare_runs = _artifacts.prepare_runs
+report_progress = _artifacts.report_progress
+resolve_case_selection = _artifacts.resolve_case_selection
+write_figure_png = _artifacts.write_figure_png
+write_solution_figures = _artifacts.write_solution_figures
 
 
-def case_name_for_gradient_profile(case_name: str, gradient_profile: str) -> str:
-    return f"{case_name}_{LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE[gradient_profile]}"
-
-
-def load_specific_case_aliases() -> dict[str, tuple[str, str]]:
-    return {
-        case_name_for_gradient_profile(run.name, gradient_profile): (
-            run.name,
-            gradient_profile,
-        )
-        for run in SANDWICH_RUNS
-        for gradient_profile in GRADIENT_PROFILES
-    }
-
-
-def case_choices() -> tuple[str, ...]:
-    base_cases = tuple(run.name for run in SANDWICH_RUNS)
-    load_specific_cases = tuple(sorted(load_specific_case_aliases()))
-    return base_cases + load_specific_cases
-
-
-def main() -> None:
-    args = parse_args()
-    runs = prepare_runs(args)
-    output_dir = args.output_dir.resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    print(f"Writing artifacts to {output_dir}")
-    print(f"Configured sandwiches: {len(runs)}")
-
-    for index, run in enumerate(runs, start=1):
-        run_case(run, index, len(runs), output_dir, write_figures=not args.csv_only)
-
-    print("Done.")
-
-
-def parse_args() -> argparse.Namespace:
-    parser_description = (
-        "Run configured Sandwich integration scenarios and save CSV/PNG artifacts."
-    )
-    parser = argparse.ArgumentParser(description=parser_description)
-    parser.add_argument(
-        "--output-dir",
-        type=Path,
-        default=Path("artifacts/sandwich_integration"),
-        help="Directory for generated CSV and PNG files.",
-    )
-    parser.add_argument(
-        "--case",
-        choices=case_choices(),
-        action="append",
-        help=(
-            "Run only the selected case or load-specific scenario. "
-            "Can be passed more than once."
+def parse_args():
+    return _artifacts.parse_args(
+        Path("artifacts/sandwich_integration"),
+        (
+            "Run configured FDM Sandwich integration scenarios and save "
+            "CSV/PNG artifacts."
         ),
     )
-    parser.add_argument(
-        "--iterations",
-        type=int,
-        help="Override iteration count for all selected sandwiches.",
-    )
-    parser.add_argument(
-        "--block-width",
-        type=int,
-        help="Override block width for all selected sandwiches; useful for smoke runs.",
-    )
-    parser.add_argument(
-        "--gradient-relaxation",
-        type=float,
-        help="Under-relaxation for copied interface gradients.",
-    )
-    parser.add_argument(
-        "--gradient-profile",
-        choices=GRADIENT_PROFILES,
-        help="Override the boundary gradient profile for selected sandwiches.",
-    )
-    overlap_group = parser.add_mutually_exclusive_group()
-    overlap_group.add_argument(
-        "--enforce-overlap-continuity",
-        dest="enforce_overlap_continuity",
-        action="store_true",
-        default=None,
-        help="Average duplicate real/ghost rows shared by adjacent blocks.",
-    )
-    overlap_group.add_argument(
-        "--no-enforce-overlap-continuity",
-        dest="enforce_overlap_continuity",
-        action="store_false",
-        help="Disable averaging of duplicate real/ghost rows.",
-    )
-    parser.add_argument(
-        "--csv-only",
-        action="store_true",
-        help="Write CSV data without PNG figures.",
-    )
-    return parser.parse_args()
-
-
-def prepare_runs(args: argparse.Namespace) -> tuple[SandwichRun, ...]:
-    if args.iterations is not None and args.iterations < 0:
-        raise SystemExit("--iterations must be non-negative.")
-    if args.block_width is not None and args.block_width < 2:
-        raise SystemExit("--block-width must be at least 2.")
-    if args.gradient_relaxation is not None:
-        if not (0 < args.gradient_relaxation <= 1):
-            raise SystemExit("--gradient-relaxation must be in the interval (0, 1].")
-
-    runs_by_name = {run.name: run for run in SANDWICH_RUNS}
-    selected_cases = resolve_case_selection(args.case, args.gradient_profile)
-    prepared = []
-    for run_name, gradient_profile in selected_cases:
-        run = runs_by_name[run_name]
-        replacements = {}
-        if args.iterations is not None:
-            replacements["iterations"] = args.iterations
-            interval = max(1, min(run.residual_every, args.iterations))
-            replacements["residual_every"] = interval
-            replacements["progress_every"] = interval
-        if args.block_width is not None:
-            replacements["block_width"] = args.block_width
-            replacements["heatmap_columns"] = min(run.heatmap_columns, args.block_width)
-            replacements["detail_heatmap_columns"] = min(
-                run.detail_heatmap_columns, args.block_width
-            )
-        if args.gradient_relaxation is not None:
-            replacements["gradient_relaxation"] = args.gradient_relaxation
-        if gradient_profile is not None:
-            replacements["gradient_profile"] = gradient_profile
-            replacements["name"] = case_name_for_gradient_profile(
-                run.name, gradient_profile
-            )
-        if args.enforce_overlap_continuity is not None:
-            replacements["enforce_overlap_continuity"] = args.enforce_overlap_continuity
-        prepared.append(dataclasses.replace(run, **replacements))
-
-    if not prepared:
-        raise SystemExit("No sandwich cases selected.")
-    return tuple(prepared)
-
-
-def resolve_case_selection(
-    case_names: Iterable[str] | None, gradient_profile: str | None
-) -> tuple[tuple[str, str | None], ...]:
-    if not case_names:
-        return tuple((run.name, gradient_profile) for run in SANDWICH_RUNS)
-
-    aliases = load_specific_case_aliases()
-    selected_cases = []
-    for case_name in case_names:
-        if case_name not in aliases:
-            selected_cases.append((case_name, gradient_profile))
-            continue
-
-        base_case_name, case_gradient_profile = aliases[case_name]
-        if gradient_profile is not None and gradient_profile != case_gradient_profile:
-            raise SystemExit(
-                f"--case {case_name!r} implies gradient profile "
-                f"{case_gradient_profile!r}, but --gradient-profile "
-                f"{gradient_profile!r} was requested."
-            )
-        selected_cases.append((base_case_name, case_gradient_profile))
-
-    return tuple(selected_cases)
 
 
 def run_case(
-    run: SandwichRun,
+    run,
     case_index: int,
     case_count: int,
     output_dir: Path,
     write_figures: bool = True,
 ) -> None:
-    case_dir = output_dir / run.name
-    case_dir.mkdir(parents=True, exist_ok=True)
-
-    print("")
-    print(f"[{case_index}/{case_count}] {run.name}")
-    print(
-        "  block_size="
-        f"({run.block_height}, {run.block_width}), "
-        f"grid_step={run.grid_step}, "
-        f"grad_factors={run.grad_factors}, "
-        f"gradient_profile={run.gradient_profile}, "
-        f"gradient_relaxation={run.gradient_relaxation}, "
-        f"enforce_overlap_continuity={run.enforce_overlap_continuity}, "
-        f"iterations={run.iterations}"
-    )
-
-    started_at = time.perf_counter()
-
-    solution = solve_case(
+    _artifacts.run_case(
         run,
-        progress_callback=lambda iteration, residual: report_progress(
-            iteration, residual, run.iterations, started_at
+        case_index,
+        case_count,
+        output_dir,
+        solve_case=solve_case,
+        write_figures=write_figures,
+    )
+
+
+def main() -> None:
+    _artifacts.main(
+        solve_case,
+        default_output_dir=Path("artifacts/sandwich_integration"),
+        parser_description=(
+            "Run configured FDM Sandwich integration scenarios and save "
+            "CSV/PNG artifacts."
         ),
     )
-
-    write_solution_csvs(case_dir, run, solution)
-    if write_figures:
-        write_solution_figures(case_dir, run, solution)
-
-    print(f"  wrote {case_dir}")
-
-
-def report_progress(
-    iteration: int, residual: float | None, total_iterations: int, started_at: float
-) -> None:
-    elapsed = time.perf_counter() - started_at
-    if residual is None:
-        print(f"  iter {iteration:>6}/{total_iterations}: {elapsed:6.1f}s")
-    else:
-        print(
-            f"  iter {iteration:>6}/{total_iterations}: "
-            f"residual={residual:.6e}, elapsed={elapsed:6.1f}s"
-        )
-
-
-def write_solution_figures(
-    case_dir: Path, run: SandwichRun, solution: SandwichSolution
-) -> None:
-    displacement = solution.displacement.drop(
-        columns=["x2_mesh_id", "x2_bottom", "x2_top"]
-    ).to_numpy()
-    heatmap_columns = min(run.heatmap_columns, displacement.shape[1])
-    detail_columns = min(run.detail_heatmap_columns, displacement.shape[1])
-    write_figure_png(
-        make_heatmap_figure(
-            displacement[:, :heatmap_columns],
-            f"Displacement {run.name}: first {heatmap_columns} columns",
-            layer_boundary_rows(run),
-        ),
-        case_dir / "displacement_heatmap.png",
-    )
-    write_figure_png(
-        make_heatmap_figure(
-            displacement[:, :detail_columns],
-            f"Displacement {run.name}: first {detail_columns} columns",
-            layer_boundary_rows(run),
-        ),
-        case_dir / "displacement_detail_heatmap.png",
-    )
-    write_figure_png(
-        make_samples_figure(
-            solution.samples,
-            f"Samples {run.name}",
-            layer_boundary_x2(run),
-        ),
-        case_dir / "samples.png",
-    )
-    write_figure_png(
-        make_residuals_figure(solution.residuals, f"Residual {run.name}"),
-        case_dir / "residuals.png",
-    )
-
-
-def layer_boundary_rows(run: SandwichRun) -> np.ndarray:
-    return np.arange(1, len(run.grad_factors)) * run.block_height - 0.5
-
-
-def layer_boundary_x2(run: SandwichRun) -> np.ndarray:
-    return layer_boundary_rows(run) * run.grid_step
-
-
-def make_heatmap_figure(
-    data: np.ndarray, title: str, layer_boundaries: np.ndarray | None = None
-):
-    fig, ax = plt.subplots(figsize=(11.2, 6.5))
-    image = ax.imshow(
-        data,
-        aspect="auto",
-        cmap=DISPLACEMENT_CMAP,
-        norm=make_displacement_norm(data),
-        origin="lower",
-    )
-    ax.set_title(title)
-    ax.set_xlabel("x1 column")
-    ax.set_ylabel("x2 row")
-    add_horizontal_layer_boundaries(ax, layer_boundaries, data.shape[0])
-    fig.colorbar(image, ax=ax, label="displacement")
-    return fig
-
-
-def make_samples_figure(
-    samples: pd.DataFrame, title: str, layer_boundaries: np.ndarray | None = None
-):
-    fig, ax = plt.subplots(figsize=(11.2, 6.5))
-    for column in samples.columns:
-        if column == "x2":
-            continue
-        ax.plot(samples["x2"], samples[column], label=column)
-    add_vertical_layer_boundaries(ax, layer_boundaries)
-    ax.set_title(title)
-    ax.set_xlabel("x2")
-    ax.set_ylabel("displacement")
-    ax.grid(True, alpha=0.3)
-    ax.legend()
-    return fig
-
-
-def add_horizontal_layer_boundaries(
-    ax, layer_boundaries: np.ndarray | None, row_count: int
-) -> None:
-    if layer_boundaries is None:
-        return
-    for boundary in layer_boundaries:
-        if 0 < boundary < row_count - 1:
-            ax.axhline(
-                boundary, color="black", linestyle="--", linewidth=0.8, alpha=0.5
-            )
-
-
-def add_vertical_layer_boundaries(ax, layer_boundaries: np.ndarray | None) -> None:
-    if layer_boundaries is None:
-        return
-    for index, boundary in enumerate(layer_boundaries):
-        ax.axvline(
-            boundary,
-            color="black",
-            linestyle="--",
-            linewidth=0.8,
-            alpha=0.5,
-            label="layer boundary" if index == 0 else "_nolegend_",
-        )
-
-
-def make_residuals_figure(residuals: pd.DataFrame, title: str):
-    fig, ax = plt.subplots(figsize=(11.2, 6.5))
-    ax.plot(residuals["iteration"], residuals["residual"])
-    ax.set_title(title)
-    ax.set_xlabel("iteration")
-    ax.set_ylabel("residual")
-    ax.grid(True, alpha=0.3)
-    return fig
-
-
-def make_displacement_norm(data: np.ndarray):
-    finite = data[np.isfinite(data)]
-    if finite.size == 0:
-        return None
-    min_value = float(finite.min())
-    max_value = float(finite.max())
-    limit = max(abs(min_value), abs(max_value))
-    if limit == 0:
-        limit = 1.0
-    return TwoSlopeNorm(vmin=-limit, vcenter=0, vmax=limit)
-
-
-def write_figure_png(
-    fig, path: Path, width: int = FIGURE_WIDTH, height: int = FIGURE_HEIGHT
-) -> None:
-    fig.set_size_inches(width / 100, height / 100)
-    fig.tight_layout()
-    fig.savefig(path, dpi=160)
-    plt.close(fig)
 
 
 if __name__ == "__main__":

--- a/scripts/fem/run_sandwich_integration.py
+++ b/scripts/fem/run_sandwich_integration.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Run the FEM Sandwich integration scenarios and save reproducible artifacts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from sandwich_numerical.artifacts import main as run_artifact_main  # noqa: E402
+from sandwich_numerical.fem.integration import solve_case  # noqa: E402
+
+
+def main() -> None:
+    run_artifact_main(
+        solve_case,
+        default_output_dir=Path("artifacts/sandwich_fem"),
+        parser_description=(
+            "Run configured FEM Sandwich integration scenarios and save "
+            "CSV/PNG artifacts."
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fdm/test_sandwich_integration_e2e.py
+++ b/tests/fdm/test_sandwich_integration_e2e.py
@@ -8,14 +8,14 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from sandwich_numerical.fdm.integration import (
+from sandwich_numerical.fdm.integration import solve_case
+from sandwich_numerical.integration import (
     GRADIENT_PROFILE_SINE,
     GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
     SANDWICH_RUNS,
     SandwichRun,
     build_gradient_vector,
     parameters_data_to_df,
-    solve_case,
 )
 from scripts.fdm.run_sandwich_integration import (
     DISPLACEMENT_CMAP,

--- a/tests/fem/test_integration.py
+++ b/tests/fem/test_integration.py
@@ -1,0 +1,109 @@
+"""Tests for the FEM Sandwich integration runner."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from sandwich_numerical.fem.integration import (
+    create_rectangular_mesh,
+    solve_case,
+    solve_displacement,
+)
+from sandwich_numerical.integration import (
+    SandwichRun,
+    layer_boundary_x2,
+    mesh_height,
+    sample_x1_coordinates,
+)
+
+
+def small_run(**overrides) -> SandwichRun:
+    values = {
+        "name": "small",
+        "block_height": 4,
+        "block_width": 5,
+        "grid_step": 0.25,
+        "grad_factors": (1.0, 1.0, 1.0),
+        "iterations": 0,
+        "residual_every": 1,
+        "progress_every": 1,
+        "heatmap_columns": 5,
+        "detail_heatmap_columns": 5,
+        "sample_x1_positions": (0.0, 0.5, 1.0),
+    }
+    values.update(overrides)
+    return SandwichRun(**values)
+
+
+def test_rectangular_mesh_contains_layer_interfaces() -> None:
+    run = small_run(grad_factors=(1.0, 2.0, 3.0))
+
+    mesh = create_rectangular_mesh(run)
+    x2_coordinates = np.unique(mesh.p[1])
+
+    assert mesh.t.shape[0] == 4
+    for boundary in layer_boundary_x2(run):
+        assert np.any(np.isclose(x2_coordinates, boundary))
+        assert np.any(np.isclose(mesh.p[1], boundary))
+
+
+def test_fem_solution_uses_fdm_displacement_artifact_shape() -> None:
+    run = small_run()
+
+    solution = solve_case(run)
+    displacement_values = solution.displacement.drop(
+        columns=["x2_mesh_id", "x2_bottom", "x2_top"]
+    ).to_numpy()
+
+    assert displacement_values.shape == (mesh_height(run), run.block_width)
+    assert list(solution.residuals.columns) == ["iteration", "residual"]
+    assert solution.residuals.shape == (1, 2)
+    assert list(solution.samples.columns) == ["x2", "x1=0.0", "x1=0.5", "x1=1.0"]
+
+
+def test_homogeneous_constant_gradient_matches_linear_solution() -> None:
+    run = small_run(block_width=6, sample_x1_positions=(0.0,))
+    gradient = np.full(mesh_height(run), 2.0)
+
+    displacement, residual = solve_displacement(run, gradient)
+
+    x_right = (run.block_width - 1) * run.grid_step
+    expected_row = gradient[0] * (sample_x1_coordinates(run) - x_right)
+    expected = np.tile(expected_row, (mesh_height(run), 1))
+
+    np.testing.assert_allclose(displacement, expected, rtol=0, atol=1e-12)
+    assert residual == pytest.approx(0.0, abs=1e-12)
+
+
+def test_fem_cli_writes_csv_artifacts(tmp_path: Path) -> None:
+    output_dir = tmp_path / "fem_artifacts"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/fem/run_sandwich_integration.py",
+            "--case",
+            "grad_factors_1_1_1",
+            "--block-width",
+            "5",
+            "--csv-only",
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    case_dir = output_dir / "grad_factors_1_1_1"
+    assert (case_dir / "residuals.csv").exists()
+    assert (case_dir / "samples.csv").exists()
+    assert (case_dir / "displacement.csv").exists()
+    assert (case_dir / "parameters.csv").exists()


### PR DESCRIPTION
## What changed

- Added a FEM implementation of the Sandwich Laplace problem using `scikit-fem` on a rectangular `MeshQuad` tensor-product grid with `ElementQuad1`.
- Added shared integration and artifact helpers so FDM and FEM produce the same CSV/PNG artifact contract.
- Kept the existing FDM import/script surface compatible through thin wrappers.
- Added a FEM CLI runner and tests for mesh interfaces, artifact shapes, analytic constant-gradient behavior, and CLI CSV smoke output.

## Why

This introduces the next solver path for the same Sandwich task without writing a custom FEM solver, while preserving the current FDM artifact workflow for comparison.

## Validation

- `poetry run pytest tests/fdm tests/fem -q`
- `poetry run flake8 sandwich_numerical/integration.py sandwich_numerical/artifacts.py sandwich_numerical/fdm/integration.py sandwich_numerical/fem/integration.py scripts/fdm/run_sandwich_integration.py scripts/fem/run_sandwich_integration.py tests/fem/test_integration.py`
- `poetry run python scripts/fem/run_sandwich_integration.py --case grad_factors_1_1_1 --block-width 20 --csv-only --output-dir /tmp/sandwich_fem_smoke`

Note: `black --check` hung without output in this local environment, so I stopped it and used the targeted `flake8` plus pytest checks above.