### PR TITLE
[codex] Add sandwich artifact pipeline

### DIFF
--- a/.github/workflows/sandwich-integration-artifacts.yml
+++ b/.github/workflows/sandwich-integration-artifacts.yml
@@ -56,7 +56,8 @@ jobs:
 
       - name: Generate Sandwich integration artifacts
         run: |
-          poetry run python scripts/fdm/run_sandwich_integration.py \
+          poetry run python scripts/run_sandwich_artifacts.py \
+            --mode ci \
             --case "${{ matrix.case }}" \
             --output-dir artifacts/sandwich_integration
 
@@ -64,6 +65,66 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sandwich-integration-${{ matrix.case }}
-          path: artifacts/sandwich_integration/${{ matrix.case }}
+          path: artifacts/sandwich_integration
+          if-no-files-found: error
+          retention-days: 30
+
+  aggregate:
+    if: github.event.pull_request.merged == true
+    name: aggregate-comparisons
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: generate
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: sandwich-integration-venv-${{ runner.os }}-3.11-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+
+      - name: Install project
+        run: poetry install --no-interaction --only-root
+
+      - name: Download Sandwich integration artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: sandwich-integration-*
+          path: artifacts/sandwich_integration
+          merge-multiple: true
+
+      - name: Generate aggregate comparison artifacts
+        run: |
+          poetry run python scripts/run_sandwich_artifacts.py \
+            --mode ci \
+            --aggregate-only \
+            --output-dir artifacts/sandwich_integration
+
+      - name: Upload aggregate Sandwich comparison artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sandwich-integration-comparison
+          path: artifacts/sandwich_integration/comparison
           if-no-files-found: error
           retention-days: 30

--- a/sandwich_numerical/artifacts.py
+++ b/sandwich_numerical/artifacts.py
@@ -341,10 +341,6 @@ def write_solution_figures(
         ),
         case_dir / "samples.png",
     )
-    write_figure_png(
-        make_residuals_figure(solution.residuals, f"Residual {run.name}"),
-        case_dir / "residuals.png",
-    )
 
 
 def make_heatmap_figure(
@@ -430,7 +426,6 @@ def write_case_comparison_figures(
         return
 
     samples_by_solver = load_solver_csvs(case_dir, "samples.csv")
-    residuals_by_solver = load_solver_csvs(case_dir, "residuals.csv")
     write_figure_png(
         make_solver_samples_comparison_figure(
             samples_by_solver,
@@ -438,13 +433,6 @@ def write_case_comparison_figures(
             layer_boundary_x2(run),
         ),
         comparison_dir / "displacement_sections.png",
-    )
-    write_figure_png(
-        make_solver_residuals_comparison_figure(
-            residuals_by_solver,
-            f"Residuals {run.name}",
-        ),
-        comparison_dir / "residuals.png",
     )
 
 
@@ -459,10 +447,6 @@ def write_all_cases_comparison_figures(
         case_name: load_solver_csvs(output_dir / case_name, "samples.csv")
         for case_name in cases
     }
-    residuals_by_case = {
-        case_name: load_solver_csvs(output_dir / case_name, "residuals.csv")
-        for case_name in cases
-    }
     runs_by_case = {case_name: run_for_case_name(case_name) for case_name in cases}
 
     comparison_dir = output_dir / "comparison"
@@ -470,12 +454,6 @@ def write_all_cases_comparison_figures(
     write_figure_png(
         make_all_cases_samples_comparison_figure(samples_by_case, runs_by_case),
         comparison_dir / "displacement_sections_all_cases.png",
-        width=1600,
-        height=1800,
-    )
-    write_figure_png(
-        make_all_cases_residuals_comparison_figure(residuals_by_case),
-        comparison_dir / "residuals_all_cases.png",
         width=1600,
         height=1800,
     )
@@ -529,16 +507,6 @@ def make_solver_samples_comparison_figure(
     return fig
 
 
-def make_solver_residuals_comparison_figure(
-    residuals_by_solver: Mapping[str, pd.DataFrame], title: str
-) -> Figure:
-    fig, ax = plt.subplots(figsize=(11.2, 6.5))
-    plot_residuals_comparison(ax, residuals_by_solver)
-    ax.set_title(title)
-    ax.legend()
-    return fig
-
-
 def make_all_cases_samples_comparison_figure(
     samples_by_case: Mapping[str, Mapping[str, pd.DataFrame]],
     runs_by_case: Mapping[str, SandwichRun],
@@ -551,18 +519,6 @@ def make_all_cases_samples_comparison_figure(
             samples_by_case[case_name],
             layer_boundary_x2(runs_by_case[case_name]),
         )
-        ax.set_title(case_name)
-    add_shared_legend(fig, axes)
-    return fig
-
-
-def make_all_cases_residuals_comparison_figure(
-    residuals_by_case: Mapping[str, Mapping[str, pd.DataFrame]]
-) -> Figure:
-    case_names = tuple(residuals_by_case)
-    fig, axes = make_case_subplots(case_names)
-    for ax, case_name in zip(axes, case_names):
-        plot_residuals_comparison(ax, residuals_by_case[case_name])
         ax.set_title(case_name)
     add_shared_legend(fig, axes)
     return fig
@@ -602,23 +558,6 @@ def plot_samples_comparison(
     add_vertical_layer_boundaries(ax, layer_boundaries)
     ax.set_xlabel("x2")
     ax.set_ylabel("displacement")
-    ax.grid(True, alpha=0.3)
-
-
-def plot_residuals_comparison(
-    ax: Axes, residuals_by_solver: Mapping[str, pd.DataFrame]
-) -> None:
-    markers = {"fdm": "o", "fem": "s"}
-    for solver_name in SOLVER_NAMES:
-        residuals = residuals_by_solver[solver_name]
-        ax.plot(
-            residuals["iteration"],
-            residuals["residual"],
-            label=solver_name,
-            marker=markers[solver_name],
-        )
-    ax.set_xlabel("iteration")
-    ax.set_ylabel("residual")
     ax.grid(True, alpha=0.3)
 
 

--- a/sandwich_numerical/artifacts.py
+++ b/sandwich_numerical/artifacts.py
@@ -483,9 +483,7 @@ def write_all_cases_comparison_figures(
 
 def discover_case_directories(output_dir: Path) -> tuple[str, ...]:
     known_cases = [
-        case_name
-        for case_name in ci_case_names()
-        if (output_dir / case_name).is_dir()
+        case_name for case_name in ci_case_names() if (output_dir / case_name).is_dir()
     ]
     if known_cases:
         return tuple(known_cases)

--- a/sandwich_numerical/artifacts.py
+++ b/sandwich_numerical/artifacts.py
@@ -6,7 +6,7 @@ import argparse
 import dataclasses
 import os
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Protocol
 
@@ -53,6 +53,7 @@ LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE = {
     GRADIENT_PROFILE_SINE: "load_sin",
     GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN: "load_parabolic",
 }
+SOLVER_NAMES = ("fdm", "fem")
 
 
 def case_name_for_gradient_profile(case_name: str, gradient_profile: str) -> str:
@@ -68,6 +69,14 @@ def load_specific_case_aliases() -> dict[str, tuple[str, str]]:
         for run in SANDWICH_RUNS
         for gradient_profile in GRADIENT_PROFILES
     }
+
+
+def ci_case_names() -> tuple[str, ...]:
+    return tuple(
+        case_name_for_gradient_profile(run.name, gradient_profile)
+        for run in SANDWICH_RUNS
+        for gradient_profile in GRADIENT_PROFILES
+    )
 
 
 def case_choices() -> tuple[str, ...]:
@@ -237,10 +246,29 @@ def run_case(
     write_figures: bool = True,
 ) -> None:
     case_dir = output_dir / run.name
+    run_case_to_dir(
+        run,
+        case_dir,
+        solve_case=solve_case,
+        write_figures=write_figures,
+        case_index=case_index,
+        case_count=case_count,
+    )
+
+
+def run_case_to_dir(
+    run: SandwichRun,
+    case_dir: Path,
+    solve_case: CaseSolver,
+    write_figures: bool = True,
+    case_index: int = 1,
+    case_count: int = 1,
+    label: str | None = None,
+) -> None:
     case_dir.mkdir(parents=True, exist_ok=True)
 
     print("")
-    print(f"[{case_index}/{case_count}] {run.name}")
+    print(f"[{case_index}/{case_count}] {label or run.name}")
     print(
         "  block_size="
         f"({run.block_height}, {run.block_width}), "
@@ -391,6 +419,214 @@ def make_residuals_figure(residuals: pd.DataFrame, title: str) -> Figure:
     ax.set_ylabel("residual")
     ax.grid(True, alpha=0.3)
     return fig
+
+
+def write_case_comparison_figures(
+    case_dir: Path, run: SandwichRun, write_figures: bool = True
+) -> None:
+    comparison_dir = case_dir / "comparison"
+    comparison_dir.mkdir(parents=True, exist_ok=True)
+    if not write_figures:
+        return
+
+    samples_by_solver = load_solver_csvs(case_dir, "samples.csv")
+    residuals_by_solver = load_solver_csvs(case_dir, "residuals.csv")
+    write_figure_png(
+        make_solver_samples_comparison_figure(
+            samples_by_solver,
+            f"Displacement sections {run.name}",
+            layer_boundary_x2(run),
+        ),
+        comparison_dir / "displacement_sections.png",
+    )
+    write_figure_png(
+        make_solver_residuals_comparison_figure(
+            residuals_by_solver,
+            f"Residuals {run.name}",
+        ),
+        comparison_dir / "residuals.png",
+    )
+
+
+def write_all_cases_comparison_figures(
+    output_dir: Path, case_names: Sequence[str] | None = None
+) -> None:
+    cases = tuple(case_names or discover_case_directories(output_dir))
+    if not cases:
+        raise FileNotFoundError(f"No case directories found in {output_dir}")
+
+    samples_by_case = {
+        case_name: load_solver_csvs(output_dir / case_name, "samples.csv")
+        for case_name in cases
+    }
+    residuals_by_case = {
+        case_name: load_solver_csvs(output_dir / case_name, "residuals.csv")
+        for case_name in cases
+    }
+    runs_by_case = {case_name: run_for_case_name(case_name) for case_name in cases}
+
+    comparison_dir = output_dir / "comparison"
+    comparison_dir.mkdir(parents=True, exist_ok=True)
+    write_figure_png(
+        make_all_cases_samples_comparison_figure(samples_by_case, runs_by_case),
+        comparison_dir / "displacement_sections_all_cases.png",
+        width=1600,
+        height=1800,
+    )
+    write_figure_png(
+        make_all_cases_residuals_comparison_figure(residuals_by_case),
+        comparison_dir / "residuals_all_cases.png",
+        width=1600,
+        height=1800,
+    )
+
+
+def discover_case_directories(output_dir: Path) -> tuple[str, ...]:
+    known_cases = [
+        case_name
+        for case_name in ci_case_names()
+        if (output_dir / case_name).is_dir()
+    ]
+    if known_cases:
+        return tuple(known_cases)
+    return tuple(sorted(path.name for path in output_dir.iterdir() if path.is_dir()))
+
+
+def load_solver_csvs(case_dir: Path, file_name: str) -> dict[str, pd.DataFrame]:
+    tables = {}
+    for solver_name in SOLVER_NAMES:
+        path = case_dir / solver_name / file_name
+        if path.exists():
+            tables[solver_name] = pd.read_csv(path)
+    missing = sorted(set(SOLVER_NAMES) - set(tables))
+    if missing:
+        raise FileNotFoundError(
+            f"Missing {file_name} for solvers {missing} in {case_dir}"
+        )
+    return tables
+
+
+def run_for_case_name(case_name: str) -> SandwichRun:
+    aliases = load_specific_case_aliases()
+    runs_by_name = {run.name: run for run in SANDWICH_RUNS}
+    if case_name in aliases:
+        base_case_name, gradient_profile = aliases[case_name]
+        return dataclasses.replace(
+            runs_by_name[base_case_name],
+            name=case_name,
+            gradient_profile=gradient_profile,
+        )
+    return runs_by_name[case_name]
+
+
+def make_solver_samples_comparison_figure(
+    samples_by_solver: Mapping[str, pd.DataFrame],
+    title: str,
+    layer_boundaries: np.ndarray | None = None,
+) -> Figure:
+    fig, ax = plt.subplots(figsize=(11.2, 6.5))
+    plot_samples_comparison(ax, samples_by_solver, layer_boundaries)
+    ax.set_title(title)
+    ax.legend(ncol=2, fontsize="small")
+    return fig
+
+
+def make_solver_residuals_comparison_figure(
+    residuals_by_solver: Mapping[str, pd.DataFrame], title: str
+) -> Figure:
+    fig, ax = plt.subplots(figsize=(11.2, 6.5))
+    plot_residuals_comparison(ax, residuals_by_solver)
+    ax.set_title(title)
+    ax.legend()
+    return fig
+
+
+def make_all_cases_samples_comparison_figure(
+    samples_by_case: Mapping[str, Mapping[str, pd.DataFrame]],
+    runs_by_case: Mapping[str, SandwichRun],
+) -> Figure:
+    case_names = tuple(samples_by_case)
+    fig, axes = make_case_subplots(case_names)
+    for ax, case_name in zip(axes, case_names):
+        plot_samples_comparison(
+            ax,
+            samples_by_case[case_name],
+            layer_boundary_x2(runs_by_case[case_name]),
+        )
+        ax.set_title(case_name)
+    add_shared_legend(fig, axes)
+    return fig
+
+
+def make_all_cases_residuals_comparison_figure(
+    residuals_by_case: Mapping[str, Mapping[str, pd.DataFrame]]
+) -> Figure:
+    case_names = tuple(residuals_by_case)
+    fig, axes = make_case_subplots(case_names)
+    for ax, case_name in zip(axes, case_names):
+        plot_residuals_comparison(ax, residuals_by_case[case_name])
+        ax.set_title(case_name)
+    add_shared_legend(fig, axes)
+    return fig
+
+
+def make_case_subplots(case_names: Sequence[str]) -> tuple[Figure, np.ndarray]:
+    row_count = int(np.ceil(len(case_names) / 2))
+    fig, axes_grid = plt.subplots(
+        row_count,
+        2,
+        figsize=(16, max(5, row_count * 4.5)),
+        squeeze=False,
+    )
+    axes = axes_grid.ravel()
+    for ax in axes[len(case_names) :]:
+        ax.set_visible(False)
+    return fig, axes[: len(case_names)]
+
+
+def plot_samples_comparison(
+    ax: Axes,
+    samples_by_solver: Mapping[str, pd.DataFrame],
+    layer_boundaries: np.ndarray | None = None,
+) -> None:
+    linestyles = {"fdm": "-", "fem": "--"}
+    for solver_name in SOLVER_NAMES:
+        samples = samples_by_solver[solver_name]
+        for column in samples.columns:
+            if column == "x2":
+                continue
+            ax.plot(
+                samples["x2"],
+                samples[column],
+                label=f"{solver_name} {column}",
+                linestyle=linestyles[solver_name],
+            )
+    add_vertical_layer_boundaries(ax, layer_boundaries)
+    ax.set_xlabel("x2")
+    ax.set_ylabel("displacement")
+    ax.grid(True, alpha=0.3)
+
+
+def plot_residuals_comparison(
+    ax: Axes, residuals_by_solver: Mapping[str, pd.DataFrame]
+) -> None:
+    markers = {"fdm": "o", "fem": "s"}
+    for solver_name in SOLVER_NAMES:
+        residuals = residuals_by_solver[solver_name]
+        ax.plot(
+            residuals["iteration"],
+            residuals["residual"],
+            label=solver_name,
+            marker=markers[solver_name],
+        )
+    ax.set_xlabel("iteration")
+    ax.set_ylabel("residual")
+    ax.grid(True, alpha=0.3)
+
+
+def add_shared_legend(fig: Figure, axes: Sequence[Axes]) -> None:
+    handles, labels = axes[0].get_legend_handles_labels()
+    fig.legend(handles, labels, loc="lower center", ncol=4, fontsize="small")
 
 
 def make_displacement_norm(data: np.ndarray) -> Normalize | None:

--- a/sandwich_numerical/artifacts.py
+++ b/sandwich_numerical/artifacts.py
@@ -49,6 +49,15 @@ class CaseSolver(Protocol):
 FIGURE_WIDTH = 1120
 FIGURE_HEIGHT = 650
 DISPLACEMENT_CMAP = "bwr"
+LAYER_GRID_SUBDIVISIONS = 5
+LAYER_BOUNDARY_COLOR = "black"
+LAYER_BOUNDARY_LINESTYLE = "-"
+LAYER_BOUNDARY_LINEWIDTH = 1.4
+LAYER_BOUNDARY_ALPHA = 0.9
+LAYER_GRID_COLOR = "black"
+LAYER_GRID_LINESTYLE = "-"
+LAYER_GRID_LINEWIDTH = 0.45
+LAYER_GRID_ALPHA = 0.18
 LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE = {
     GRADIENT_PROFILE_SINE: "load_sin",
     GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN: "load_parabolic",
@@ -357,6 +366,7 @@ def make_heatmap_figure(
     ax.set_title(title)
     ax.set_xlabel("x1 column")
     ax.set_ylabel("x2 row")
+    add_layer_aligned_y_grid(ax, layer_boundaries)
     add_horizontal_layer_boundaries(ax, layer_boundaries, data.shape[0])
     fig.colorbar(image, ax=ax, label="displacement")
     return fig
@@ -370,11 +380,12 @@ def make_samples_figure(
         if column == "x2":
             continue
         ax.plot(samples["x2"], samples[column], label=column)
+    add_layer_aligned_x_grid(ax, layer_boundaries)
     add_vertical_layer_boundaries(ax, layer_boundaries)
     ax.set_title(title)
     ax.set_xlabel("x2")
     ax.set_ylabel("displacement")
-    ax.grid(True, alpha=0.3)
+    ax.grid(True, axis="y", alpha=0.3)
     ax.legend()
     return fig
 
@@ -387,7 +398,12 @@ def add_horizontal_layer_boundaries(
     for boundary in layer_boundaries:
         if 0 < boundary < row_count - 1:
             ax.axhline(
-                boundary, color="black", linestyle="--", linewidth=0.8, alpha=0.5
+                boundary,
+                color=LAYER_BOUNDARY_COLOR,
+                linestyle=LAYER_BOUNDARY_LINESTYLE,
+                linewidth=LAYER_BOUNDARY_LINEWIDTH,
+                alpha=LAYER_BOUNDARY_ALPHA,
+                zorder=4,
             )
 
 
@@ -399,11 +415,12 @@ def add_vertical_layer_boundaries(
     for index, boundary in enumerate(layer_boundaries):
         ax.axvline(
             boundary,
-            color="black",
-            linestyle="--",
-            linewidth=0.8,
-            alpha=0.5,
+            color=LAYER_BOUNDARY_COLOR,
+            linestyle=LAYER_BOUNDARY_LINESTYLE,
+            linewidth=LAYER_BOUNDARY_LINEWIDTH,
+            alpha=LAYER_BOUNDARY_ALPHA,
             label="layer boundary" if index == 0 else "_nolegend_",
+            zorder=4,
         )
 
 
@@ -555,10 +572,90 @@ def plot_samples_comparison(
                 label=f"{solver_name} {column}",
                 linestyle=linestyles[solver_name],
             )
-    add_vertical_layer_boundaries(ax, layer_boundaries)
     ax.set_xlabel("x2")
     ax.set_ylabel("displacement")
-    ax.grid(True, alpha=0.3)
+    add_layer_aligned_x_grid(ax, layer_boundaries)
+    add_vertical_layer_boundaries(ax, layer_boundaries)
+    ax.grid(True, axis="y", alpha=0.3)
+
+
+def add_layer_aligned_x_grid(ax: Axes, layer_boundaries: np.ndarray | None) -> None:
+    ticks = layer_aligned_ticks(layer_boundaries, *ax.get_xlim())
+    if ticks.size == 0:
+        ax.grid(True, alpha=0.3)
+        return
+
+    ax.set_xticks(ticks, minor=True)
+    ax.tick_params(axis="x", which="minor", length=0)
+    ax.grid(False, axis="x", which="major")
+    ax.grid(
+        True,
+        axis="x",
+        which="minor",
+        color=LAYER_GRID_COLOR,
+        linestyle=LAYER_GRID_LINESTYLE,
+        linewidth=LAYER_GRID_LINEWIDTH,
+        alpha=LAYER_GRID_ALPHA,
+    )
+
+
+def add_layer_aligned_y_grid(ax: Axes, layer_boundaries: np.ndarray | None) -> None:
+    ticks = layer_aligned_ticks(layer_boundaries, *ax.get_ylim())
+    if ticks.size == 0:
+        return
+
+    ax.set_yticks(ticks, minor=True)
+    ax.tick_params(axis="y", which="minor", length=0)
+    ax.grid(
+        True,
+        axis="y",
+        which="minor",
+        color=LAYER_GRID_COLOR,
+        linestyle=LAYER_GRID_LINESTYLE,
+        linewidth=LAYER_GRID_LINEWIDTH,
+        alpha=LAYER_GRID_ALPHA,
+    )
+
+
+def layer_aligned_ticks(
+    layer_boundaries: np.ndarray | None,
+    lower: float,
+    upper: float,
+    subdivisions: int = LAYER_GRID_SUBDIVISIONS,
+) -> np.ndarray:
+    if layer_boundaries is None or subdivisions <= 0:
+        return np.array([], dtype=float)
+
+    boundaries = np.asarray(layer_boundaries, dtype=float)
+    boundaries = np.sort(boundaries[np.isfinite(boundaries)])
+    if boundaries.size == 0:
+        return np.array([], dtype=float)
+
+    axis_min = min(lower, upper)
+    axis_max = max(lower, upper)
+    layer_thickness = infer_layer_thickness(boundaries, axis_min, axis_max)
+    if layer_thickness <= 0:
+        return np.array([], dtype=float)
+
+    spacing = layer_thickness / subdivisions
+    layers_before = int(np.ceil((boundaries[0] - axis_min) / layer_thickness))
+    first_layer_start = boundaries[0] - layers_before * layer_thickness
+    count = int(np.ceil((axis_max - first_layer_start) / spacing)) + 1
+    ticks = first_layer_start + spacing * np.arange(count + 1, dtype=float)
+    tolerance = spacing * 1e-6
+    return np.asarray(
+        ticks[(axis_min - tolerance <= ticks) & (ticks <= axis_max + tolerance)],
+        dtype=float,
+    )
+
+
+def infer_layer_thickness(
+    layer_boundaries: np.ndarray, axis_min: float, axis_max: float
+) -> float:
+    if layer_boundaries.size >= 2:
+        return float(np.median(np.diff(layer_boundaries)))
+
+    return float(max(layer_boundaries[0] - axis_min, axis_max - layer_boundaries[0]))
 
 
 def add_shared_legend(fig: Figure, axes: Sequence[Axes]) -> None:

--- a/sandwich_numerical/artifacts.py
+++ b/sandwich_numerical/artifacts.py
@@ -374,6 +374,7 @@ def make_samples_figure(
     ax.set_title(title)
     ax.set_xlabel("x2")
     ax.set_ylabel("displacement")
+    anchor_displacement_axis_at_zero(ax)
     ax.grid(True, alpha=0.3)
     ax.legend()
     return fig
@@ -558,7 +559,16 @@ def plot_samples_comparison(
     add_vertical_layer_boundaries(ax, layer_boundaries)
     ax.set_xlabel("x2")
     ax.set_ylabel("displacement")
+    anchor_displacement_axis_at_zero(ax)
     ax.grid(True, alpha=0.3)
+
+
+def anchor_displacement_axis_at_zero(ax: Axes) -> None:
+    bottom, top = ax.get_ylim()
+    if bottom > 0:
+        ax.set_ylim(bottom=0.0, top=top)
+    elif top < 0:
+        ax.set_ylim(bottom=bottom, top=0.0)
 
 
 def add_shared_legend(fig: Figure, axes: Sequence[Axes]) -> None:

--- a/sandwich_numerical/artifacts.py
+++ b/sandwich_numerical/artifacts.py
@@ -568,7 +568,7 @@ def make_all_cases_residuals_comparison_figure(
     return fig
 
 
-def make_case_subplots(case_names: Sequence[str]) -> tuple[Figure, np.ndarray]:
+def make_case_subplots(case_names: Sequence[str]) -> tuple[Figure, list[Axes]]:
     row_count = int(np.ceil(len(case_names) / 2))
     fig, axes_grid = plt.subplots(
         row_count,
@@ -579,7 +579,7 @@ def make_case_subplots(case_names: Sequence[str]) -> tuple[Figure, np.ndarray]:
     axes = axes_grid.ravel()
     for ax in axes[len(case_names) :]:
         ax.set_visible(False)
-    return fig, axes[: len(case_names)]
+    return fig, list(axes[: len(case_names)])
 
 
 def plot_samples_comparison(

--- a/sandwich_numerical/artifacts.py
+++ b/sandwich_numerical/artifacts.py
@@ -374,7 +374,6 @@ def make_samples_figure(
     ax.set_title(title)
     ax.set_xlabel("x2")
     ax.set_ylabel("displacement")
-    anchor_displacement_axis_at_zero(ax)
     ax.grid(True, alpha=0.3)
     ax.legend()
     return fig
@@ -559,16 +558,7 @@ def plot_samples_comparison(
     add_vertical_layer_boundaries(ax, layer_boundaries)
     ax.set_xlabel("x2")
     ax.set_ylabel("displacement")
-    anchor_displacement_axis_at_zero(ax)
     ax.grid(True, alpha=0.3)
-
-
-def anchor_displacement_axis_at_zero(ax: Axes) -> None:
-    bottom, top = ax.get_ylim()
-    if bottom > 0:
-        ax.set_ylim(bottom=0.0, top=top)
-    elif top < 0:
-        ax.set_ylim(bottom=bottom, top=0.0)
 
 
 def add_shared_legend(fig: Figure, axes: Sequence[Axes]) -> None:

--- a/scripts/run_sandwich_artifacts.py
+++ b/scripts/run_sandwich_artifacts.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Run unified FDM/FEM Sandwich artifact generation locally or in CI."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from sandwich_numerical import artifacts  # noqa: E402
+from sandwich_numerical.fdm.integration import (  # noqa: E402
+    solve_case as solve_fdm_case,
+)
+from sandwich_numerical.fem.integration import (  # noqa: E402
+    solve_case as solve_fem_case,
+)
+
+
+LOCAL_DEFAULT_CASE = "grad_factors_1_1_1_load_sin"
+LOCAL_DEFAULT_BLOCK_WIDTH = 50
+SOLVERS = {
+    "fdm": solve_fdm_case,
+    "fem": solve_fem_case,
+}
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = selected_output_dir(args).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.aggregate_only:
+        print(f"Building aggregate comparisons from {output_dir}")
+        artifacts.write_all_cases_comparison_figures(
+            output_dir,
+            case_names=selected_case_names(args, aggregate=True),
+        )
+        print("Done.")
+        return
+
+    runs = artifacts.prepare_runs(prepared_run_args(args))
+    solver_names = selected_solver_names(args.solver)
+    print(f"Writing artifacts to {output_dir}")
+    print(f"Configured sandwiches: {len(runs)}")
+    print(f"Configured solvers: {', '.join(solver_names)}")
+
+    for index, run in enumerate(runs, start=1):
+        case_dir = output_dir / run.name
+        for solver_name in solver_names:
+            artifacts.run_case_to_dir(
+                run,
+                case_dir / solver_name,
+                solve_case=SOLVERS[solver_name],
+                write_figures=not args.csv_only,
+                case_index=index,
+                case_count=len(runs),
+                label=f"{run.name} [{solver_name}]",
+            )
+
+        if solver_names == artifacts.SOLVER_NAMES:
+            artifacts.write_case_comparison_figures(
+                case_dir,
+                run,
+                write_figures=not args.csv_only,
+            )
+
+    if solver_names == artifacts.SOLVER_NAMES and not args.csv_only and len(runs) > 1:
+        artifacts.write_all_cases_comparison_figures(
+            output_dir,
+            case_names=tuple(run.name for run in runs),
+        )
+
+    print("Done.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate Sandwich FDM/FEM CSV and PNG artifacts."
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("local", "ci"),
+        default="local",
+        help="Use local debug defaults or CI defaults.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for generated CSV and PNG files.",
+    )
+    parser.add_argument(
+        "--case",
+        choices=artifacts.case_choices(),
+        action="append",
+        help="Run only the selected case or load-specific scenario.",
+    )
+    parser.add_argument(
+        "--all-cases",
+        action="store_true",
+        help="Run all CI load-specific cases.",
+    )
+    parser.add_argument(
+        "--solver",
+        choices=("fdm", "fem", "both"),
+        default="both",
+        help="Select which solver artifacts to generate.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        help="Override iteration count for all selected sandwiches.",
+    )
+    parser.add_argument(
+        "--block-width",
+        type=int,
+        help="Override block width; useful for local smoke runs.",
+    )
+    parser.add_argument(
+        "--gradient-relaxation",
+        type=float,
+        help="Under-relaxation for copied interface gradients.",
+    )
+    parser.add_argument(
+        "--gradient-profile",
+        choices=artifacts.GRADIENT_PROFILES,
+        help="Override the boundary gradient profile for selected sandwiches.",
+    )
+    overlap_group = parser.add_mutually_exclusive_group()
+    overlap_group.add_argument(
+        "--enforce-overlap-continuity",
+        dest="enforce_overlap_continuity",
+        action="store_true",
+        default=None,
+        help="Average duplicate real/ghost rows shared by adjacent blocks.",
+    )
+    overlap_group.add_argument(
+        "--no-enforce-overlap-continuity",
+        dest="enforce_overlap_continuity",
+        action="store_false",
+        help="Disable averaging of duplicate real/ghost rows.",
+    )
+    parser.add_argument(
+        "--csv-only",
+        action="store_true",
+        help="Write CSV data without PNG figures.",
+    )
+    parser.add_argument(
+        "--aggregate-only",
+        action="store_true",
+        help="Read existing per-case CSV files and build only all-case comparisons.",
+    )
+    return parser.parse_args()
+
+
+def selected_output_dir(args: argparse.Namespace) -> Path:
+    if args.output_dir is not None:
+        return args.output_dir
+    if args.mode == "ci":
+        return Path("artifacts/sandwich_integration")
+    return Path("artifacts/local_sandwich_integration")
+
+
+def selected_case_names(
+    args: argparse.Namespace, aggregate: bool = False
+) -> tuple[str, ...]:
+    if args.case:
+        return tuple(args.case)
+    if args.mode == "ci" or args.all_cases or aggregate:
+        return artifacts.ci_case_names()
+    return (LOCAL_DEFAULT_CASE,)
+
+
+def prepared_run_args(args: argparse.Namespace) -> argparse.Namespace:
+    block_width = args.block_width
+    if args.mode == "local" and not args.all_cases and block_width is None:
+        block_width = LOCAL_DEFAULT_BLOCK_WIDTH
+
+    return argparse.Namespace(
+        case=list(selected_case_names(args)),
+        iterations=args.iterations,
+        block_width=block_width,
+        gradient_relaxation=args.gradient_relaxation,
+        gradient_profile=args.gradient_profile,
+        enforce_overlap_continuity=args.enforce_overlap_continuity,
+    )
+
+
+def selected_solver_names(solver: str) -> tuple[str, ...]:
+    if solver == "both":
+        return artifacts.SOLVER_NAMES
+    return (solver,)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sandwich_artifacts_pipeline.py
+++ b/tests/test_sandwich_artifacts_pipeline.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import pandas as pd
 
 from sandwich_numerical import artifacts
@@ -45,45 +44,6 @@ def test_all_case_comparison_writes_only_displacement_png(tmp_path: Path) -> Non
     comparison_dir = output_dir / "comparison"
     assert (comparison_dir / "displacement_sections_all_cases.png").exists()
     assert not (comparison_dir / "residuals_all_cases.png").exists()
-
-
-def test_samples_figure_uses_zero_as_minimum_for_positive_displacements() -> None:
-    fig = artifacts.make_samples_figure(
-        pd.DataFrame({"x2": [0.0, 1.0], "x1=0.0": [1.0, 2.0]}),
-        "positive",
-    )
-    try:
-        bottom, top = fig.axes[0].get_ylim()
-        assert bottom == 0.0
-        assert top > 2.0
-    finally:
-        plt.close(fig)
-
-
-def test_samples_figure_uses_zero_as_maximum_for_negative_displacements() -> None:
-    fig = artifacts.make_samples_figure(
-        pd.DataFrame({"x2": [0.0, 1.0], "x1=0.0": [-2.0, -1.0]}),
-        "negative",
-    )
-    try:
-        bottom, top = fig.axes[0].get_ylim()
-        assert bottom < -2.0
-        assert top == 0.0
-    finally:
-        plt.close(fig)
-
-
-def test_samples_figure_keeps_mixed_displacement_axis_auto_scaled() -> None:
-    fig = artifacts.make_samples_figure(
-        pd.DataFrame({"x2": [0.0, 1.0], "x1=0.0": [-1.0, 2.0]}),
-        "mixed",
-    )
-    try:
-        bottom, top = fig.axes[0].get_ylim()
-        assert bottom < -1.0
-        assert top > 2.0
-    finally:
-        plt.close(fig)
 
 
 def test_unified_cli_local_csv_smoke(tmp_path: Path) -> None:

--- a/tests/test_sandwich_artifacts_pipeline.py
+++ b/tests/test_sandwich_artifacts_pipeline.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import pandas as pd
 
 from sandwich_numerical import artifacts
@@ -44,6 +45,45 @@ def test_all_case_comparison_writes_only_displacement_png(tmp_path: Path) -> Non
     comparison_dir = output_dir / "comparison"
     assert (comparison_dir / "displacement_sections_all_cases.png").exists()
     assert not (comparison_dir / "residuals_all_cases.png").exists()
+
+
+def test_samples_figure_uses_zero_as_minimum_for_positive_displacements() -> None:
+    fig = artifacts.make_samples_figure(
+        pd.DataFrame({"x2": [0.0, 1.0], "x1=0.0": [1.0, 2.0]}),
+        "positive",
+    )
+    try:
+        bottom, top = fig.axes[0].get_ylim()
+        assert bottom == 0.0
+        assert top > 2.0
+    finally:
+        plt.close(fig)
+
+
+def test_samples_figure_uses_zero_as_maximum_for_negative_displacements() -> None:
+    fig = artifacts.make_samples_figure(
+        pd.DataFrame({"x2": [0.0, 1.0], "x1=0.0": [-2.0, -1.0]}),
+        "negative",
+    )
+    try:
+        bottom, top = fig.axes[0].get_ylim()
+        assert bottom < -2.0
+        assert top == 0.0
+    finally:
+        plt.close(fig)
+
+
+def test_samples_figure_keeps_mixed_displacement_axis_auto_scaled() -> None:
+    fig = artifacts.make_samples_figure(
+        pd.DataFrame({"x2": [0.0, 1.0], "x1=0.0": [-1.0, 2.0]}),
+        "mixed",
+    )
+    try:
+        bottom, top = fig.axes[0].get_ylim()
+        assert bottom < -1.0
+        assert top > 2.0
+    finally:
+        plt.close(fig)
 
 
 def test_unified_cli_local_csv_smoke(tmp_path: Path) -> None:

--- a/tests/test_sandwich_artifacts_pipeline.py
+++ b/tests/test_sandwich_artifacts_pipeline.py
@@ -1,0 +1,117 @@
+"""Tests for the unified Sandwich artifact pipeline."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from sandwich_numerical import artifacts
+
+
+def sample_table(scale: float) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "x2": [0.0, 0.5, 1.0],
+            "x1=0.0": [0.0, scale, 0.0],
+            "x1=0.5": [scale, 0.0, -scale],
+        }
+    )
+
+
+def residual_table(value: float) -> pd.DataFrame:
+    return pd.DataFrame({"iteration": [0], "residual": [value]})
+
+
+def write_solver_tables(case_dir: Path) -> None:
+    for solver_name, scale in (("fdm", 1.0), ("fem", 0.9)):
+        solver_dir = case_dir / solver_name
+        solver_dir.mkdir(parents=True)
+        sample_table(scale).to_csv(solver_dir / "samples.csv", index=False)
+        residual_table(scale).to_csv(solver_dir / "residuals.csv", index=False)
+
+
+def test_residual_comparison_accepts_single_iteration_point() -> None:
+    fig = artifacts.make_solver_residuals_comparison_figure(
+        {
+            "fdm": residual_table(1.0),
+            "fem": residual_table(0.5),
+        },
+        "residuals",
+    )
+    try:
+        assert len(fig.axes[0].lines) == 2
+        assert [line.get_marker() for line in fig.axes[0].lines] == ["o", "s"]
+    finally:
+        plt.close(fig)
+
+
+def test_all_case_comparison_writes_expected_pngs(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    case_names = artifacts.ci_case_names()[:2]
+    for case_name in case_names:
+        write_solver_tables(output_dir / case_name)
+
+    artifacts.write_all_cases_comparison_figures(output_dir, case_names=case_names)
+
+    comparison_dir = output_dir / "comparison"
+    assert (comparison_dir / "displacement_sections_all_cases.png").exists()
+    assert (comparison_dir / "residuals_all_cases.png").exists()
+
+
+def test_unified_cli_local_csv_smoke(tmp_path: Path) -> None:
+    output_dir = tmp_path / "local"
+
+    result = run_artifact_cli(
+        "--mode",
+        "local",
+        "--case",
+        "grad_factors_1_1_1_load_sin",
+        "--block-width",
+        "5",
+        "--csv-only",
+        "--output-dir",
+        str(output_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    case_dir = output_dir / "grad_factors_1_1_1_load_sin"
+    for solver_name in artifacts.SOLVER_NAMES:
+        assert (case_dir / solver_name / "samples.csv").exists()
+        assert (case_dir / solver_name / "displacement.csv").exists()
+        assert (case_dir / solver_name / "residuals.csv").exists()
+        assert (case_dir / solver_name / "parameters.csv").exists()
+    assert (case_dir / "comparison").is_dir()
+
+
+def test_unified_cli_ci_like_case_writes_comparison_pngs(tmp_path: Path) -> None:
+    output_dir = tmp_path / "ci"
+
+    result = run_artifact_cli(
+        "--mode",
+        "ci",
+        "--case",
+        "grad_factors_1_1_1_load_sin",
+        "--block-width",
+        "5",
+        "--output-dir",
+        str(output_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    comparison_dir = output_dir / "grad_factors_1_1_1_load_sin" / "comparison"
+    assert (comparison_dir / "displacement_sections.png").exists()
+    assert (comparison_dir / "residuals.png").exists()
+
+
+def run_artifact_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "scripts/run_sandwich_artifacts.py", *args],
+        cwd=Path(__file__).resolve().parents[1],
+        check=False,
+        text=True,
+        capture_output=True,
+    )

--- a/tests/test_sandwich_artifacts_pipeline.py
+++ b/tests/test_sandwich_artifacts_pipeline.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
+import pytest
 
 from sandwich_numerical import artifacts
 
@@ -44,6 +47,52 @@ def test_all_case_comparison_writes_only_displacement_png(tmp_path: Path) -> Non
     comparison_dir = output_dir / "comparison"
     assert (comparison_dir / "displacement_sections_all_cases.png").exists()
     assert not (comparison_dir / "residuals_all_cases.png").exists()
+
+
+def test_layer_aligned_ticks_subdivide_layer_thickness() -> None:
+    ticks = artifacts.layer_aligned_ticks(
+        np.array([0.1025, 0.2075]),
+        lower=0.0,
+        upper=0.31,
+    )
+
+    np.testing.assert_allclose(np.diff(ticks), 0.105 / 5, rtol=0, atol=1e-14)
+    assert ticks.tolist() == pytest.approx(
+        [
+            0.0185,
+            0.0395,
+            0.0605,
+            0.0815,
+            0.1025,
+            0.1235,
+            0.1445,
+            0.1655,
+            0.1865,
+            0.2075,
+            0.2285,
+            0.2495,
+            0.2705,
+            0.2915,
+        ]
+    )
+
+
+def test_samples_figure_uses_layer_aligned_grid_and_bright_boundaries() -> None:
+    fig = artifacts.make_samples_figure(
+        sample_table(1.0),
+        "samples",
+        layer_boundaries=np.array([0.5]),
+    )
+    try:
+        boundary = fig.axes[0].lines[-1]
+
+        assert boundary.get_label() == "layer boundary"
+        assert boundary.get_linestyle() == "-"
+        assert boundary.get_linewidth() == pytest.approx(1.4)
+        assert boundary.get_alpha() == pytest.approx(0.9)
+        assert fig.axes[0].get_xticks(minor=True).size > 0
+    finally:
+        plt.close(fig)
 
 
 def test_unified_cli_local_csv_smoke(tmp_path: Path) -> None:

--- a/tests/test_sandwich_artifacts_pipeline.py
+++ b/tests/test_sandwich_artifacts_pipeline.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import pandas as pd
 
 from sandwich_numerical import artifacts
@@ -34,22 +33,7 @@ def write_solver_tables(case_dir: Path) -> None:
         residual_table(scale).to_csv(solver_dir / "residuals.csv", index=False)
 
 
-def test_residual_comparison_accepts_single_iteration_point() -> None:
-    fig = artifacts.make_solver_residuals_comparison_figure(
-        {
-            "fdm": residual_table(1.0),
-            "fem": residual_table(0.5),
-        },
-        "residuals",
-    )
-    try:
-        assert len(fig.axes[0].lines) == 2
-        assert [line.get_marker() for line in fig.axes[0].lines] == ["o", "s"]
-    finally:
-        plt.close(fig)
-
-
-def test_all_case_comparison_writes_expected_pngs(tmp_path: Path) -> None:
+def test_all_case_comparison_writes_only_displacement_png(tmp_path: Path) -> None:
     output_dir = tmp_path / "artifacts"
     case_names = artifacts.ci_case_names()[:2]
     for case_name in case_names:
@@ -59,7 +43,7 @@ def test_all_case_comparison_writes_expected_pngs(tmp_path: Path) -> None:
 
     comparison_dir = output_dir / "comparison"
     assert (comparison_dir / "displacement_sections_all_cases.png").exists()
-    assert (comparison_dir / "residuals_all_cases.png").exists()
+    assert not (comparison_dir / "residuals_all_cases.png").exists()
 
 
 def test_unified_cli_local_csv_smoke(tmp_path: Path) -> None:
@@ -104,7 +88,12 @@ def test_unified_cli_ci_like_case_writes_comparison_pngs(tmp_path: Path) -> None
     assert result.returncode == 0, result.stderr
     comparison_dir = output_dir / "grad_factors_1_1_1_load_sin" / "comparison"
     assert (comparison_dir / "displacement_sections.png").exists()
-    assert (comparison_dir / "residuals.png").exists()
+    assert not (comparison_dir / "residuals.png").exists()
+
+    for solver_name in artifacts.SOLVER_NAMES:
+        solver_dir = output_dir / "grad_factors_1_1_1_load_sin" / solver_name
+        assert (solver_dir / "residuals.csv").exists()
+        assert not (solver_dir / "residuals.png").exists()
 
 
 def run_artifact_cli(*args: str) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Summary
- add a unified `scripts/run_sandwich_artifacts.py` CLI for local and CI artifact generation
- generate FDM/FEM artifacts under per-case solver directories plus per-case comparison plots
- update the GitHub Actions workflow to run the unified CLI and build aggregate comparison artifacts
- add smoke/unit coverage for local, CI-like, and aggregate comparison flows

## Validation
- `poetry run pytest tests/fdm tests/fem tests/test_sandwich_artifacts_pipeline.py -q`
- `python -m py_compile sandwich_numerical/artifacts.py scripts/run_sandwich_artifacts.py tests/test_sandwich_artifacts_pipeline.py`
- `git diff --check`
- local aggregate smoke run with two small cases and `--aggregate-only`

Note: `black --check` hung in the local environment, so formatting was checked manually via line-length scan plus syntax/tests.