### PR TITLE
[codex] Run sandwich artifacts on every push

### DIFF
--- a/.github/workflows/sandwich-integration-artifacts.yml
+++ b/.github/workflows/sandwich-integration-artifacts.yml
@@ -7,20 +7,9 @@ on:
 
 jobs:
   generate:
-    name: ${{ matrix.case }}
+    name: generate-artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 120
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - case: grad_factors_1_1_1_load_sin
-          - case: grad_factors_1_1_1_load_parabolic
-          - case: grad_factors_1_1000_1_load_sin
-          - case: grad_factors_1_1000_1_load_parabolic
-          - case: grad_factors_1000_1_1000_1_1000_load_sin
-          - case: grad_factors_1000_1_1000_1_1000_load_parabolic
 
     steps:
       - uses: actions/checkout@v4
@@ -55,70 +44,12 @@ jobs:
         run: |
           poetry run python scripts/run_sandwich_artifacts.py \
             --mode ci \
-            --case "${{ matrix.case }}" \
             --output-dir artifacts/sandwich_integration
 
       - name: Upload Sandwich integration artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: sandwich-integration-${{ matrix.case }}
+          name: sandwich-integration
           path: artifacts/sandwich_integration
-          if-no-files-found: error
-          retention-days: 30
-
-  aggregate:
-    name: aggregate-comparisons
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: generate
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: latest
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: sandwich-integration-venv-${{ runner.os }}-3.11-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction --only-root
-
-      - name: Download Sandwich integration artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: sandwich-integration-*
-          path: artifacts/sandwich_integration
-          merge-multiple: true
-
-      - name: Generate aggregate comparison artifacts
-        run: |
-          poetry run python scripts/run_sandwich_artifacts.py \
-            --mode ci \
-            --aggregate-only \
-            --output-dir artifacts/sandwich_integration
-
-      - name: Upload aggregate Sandwich comparison artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: sandwich-integration-comparison
-          path: artifacts/sandwich_integration/comparison
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/sandwich-integration-artifacts.yml
+++ b/.github/workflows/sandwich-integration-artifacts.yml
@@ -1,13 +1,12 @@
 name: Sandwich Integration Artifacts
 
 on:
-  pull_request:
-    branches: [ master ]
-    types: [ closed ]
+  push:
+    branches:
+      - "**"
 
 jobs:
   generate:
-    if: github.event.pull_request.merged == true
     name: ${{ matrix.case }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -25,8 +24,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: master
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -70,7 +67,6 @@ jobs:
           retention-days: 30
 
   aggregate:
-    if: github.event.pull_request.merged == true
     name: aggregate-comparisons
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -78,8 +74,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: master
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- run the Sandwich Integration Artifacts workflow on every push to any branch
- remove the merged-PR-only job guards
- checkout the pushed commit instead of forcing `master`

## Validation
- `git diff --check`
- reviewed the workflow diff locally

This keeps generated artifacts available from branch commits instead of only after merging to `master`.