### PR TITLE
[codex] Normalize parabolic sandwich load

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,35 @@ poetry run pytest tests/ --cov=sandwich_numerical --cov-report=html
 poetry run pytest tests/ --cov=sandwich_numerical --cov-report=term-missing
 ```
 
+### Sandwich Integration Scenarios
+
+The reproducible integration artifacts compare FDM and FEM solutions for a
+rectangular sandwich domain with `grid_step=0.005`, `block_height=21`, and
+`block_width=3000` unless overridden from the CLI.
+
+Configured layer scenarios:
+
+- `grad_factors_1_1_1` - 3 layers with gradient factors `(1.0, 1.0, 1.0)`.
+- `grad_factors_1_1000_1` - 3 layers with a stiff middle layer, gradient factors `(1.0, 1000.0, 1.0)`.
+- `grad_factors_1000_1_1000_1_1000` - 5 alternating layers with gradient factors `(1000.0, 1.0, 1000.0, 1.0, 1000.0)`.
+
+Each scenario is run with two left-boundary load profiles:
+
+- `sine` - `sin(2*pi*i/(height - 1))`, zero at the lower and upper boundaries, with max absolute value close to 1 on the discrete mesh.
+- `parabolic_zero_mean` - `(x2^2 - L^2/12)` normalized by its max absolute value; this keeps the profile symmetric and zero-mean while making `max |load| = 1`.
+
+Generate local artifacts with:
+
+```bash
+poetry run python scripts/run_sandwich_artifacts.py \
+  --mode local \
+  --all-cases \
+  --output-dir artifacts/local_sandwich_integration
+```
+
+Each generated run directory contains a short `README.md` with the layer count,
+gradient factors, load profile, and output layout for that run.
+
 ## Key Components
 
 ### Sandwich Class

--- a/README.md
+++ b/README.md
@@ -102,7 +102,11 @@ Configured layer scenarios:
 Each scenario is run with two left-boundary load profiles:
 
 - `sine` - `sin(2*pi*i/(height - 1))`, zero at the lower and upper boundaries, with max absolute value close to 1 on the discrete mesh.
-- `parabolic_zero_mean` - `(x2^2 - L^2/12)` normalized by its max absolute value; this keeps the profile symmetric and zero-mean while making `max |load| = 1`.
+- `parabolic_zero_mean` - `6*(x/L)^2 - 1/2`, where `x` is the centered thickness coordinate in `[-L/2, L/2]`; this keeps the profile symmetric and zero-mean while making `max |load| = 1`.
+
+The parabolic profile is chosen to compare a symmetric non-sinusoidal load shape
+against the sine case without adding a net boundary-gradient bias or a different
+load amplitude scale.
 
 Generate local artifacts with:
 

--- a/sandwich_numerical/artifacts.py
+++ b/sandwich_numerical/artifacts.py
@@ -335,6 +335,7 @@ def write_run_readme(
     row_count = run.block_height * len(run.grad_factors)
     full_thickness = (row_count - 1) * run.grid_step
     layer_count = len(run.grad_factors)
+    load_description = LOAD_DESCRIPTION_BY_GRADIENT_PROFILE[run.gradient_profile]
     if output_lines is None:
         output_lines = (
             "`fdm/` contains finite-difference CSV/PNG artifacts.",
@@ -357,7 +358,7 @@ def write_run_readme(
             "## Boundary Load",
             "",
             f"- Profile: {run.gradient_profile}",
-            f"- Definition: {LOAD_DESCRIPTION_BY_GRADIENT_PROFILE[run.gradient_profile]}",
+            f"- Definition: {load_description}",
             f"- Discrete min/max: {gradient.min():.12g} / {gradient.max():.12g}",
             f"- Discrete max |load|: {np.max(np.abs(gradient)):.12g}",
             "",

--- a/sandwich_numerical/artifacts.py
+++ b/sandwich_numerical/artifacts.py
@@ -69,8 +69,8 @@ LOAD_DESCRIPTION_BY_GRADIENT_PROFILE = {
         "with max absolute value close to 1 on the discrete mesh"
     ),
     GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN: (
-        "(x2^2 - L^2/12) normalized by its max absolute value; symmetric, "
-        "zero mean, with max absolute value 1"
+        "6*(x/L)^2 - 1/2 for centered thickness coordinate x in [-L/2, L/2]; "
+        "symmetric, zero mean, with max absolute value 1"
     ),
 }
 SOLVER_NAMES = ("fdm", "fem")

--- a/sandwich_numerical/artifacts.py
+++ b/sandwich_numerical/artifacts.py
@@ -24,6 +24,7 @@ import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
 
 from sandwich_numerical.integration import (  # noqa: E402
+    build_gradient_vector,
     GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN,
     GRADIENT_PROFILE_SINE,
     GRADIENT_PROFILES,
@@ -61,6 +62,16 @@ LAYER_GRID_ALPHA = 0.18
 LOAD_SHAPE_NAME_BY_GRADIENT_PROFILE = {
     GRADIENT_PROFILE_SINE: "load_sin",
     GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN: "load_parabolic",
+}
+LOAD_DESCRIPTION_BY_GRADIENT_PROFILE = {
+    GRADIENT_PROFILE_SINE: (
+        "sin(2*pi*i/(height - 1)); zero at the lower and upper boundaries, "
+        "with max absolute value close to 1 on the discrete mesh"
+    ),
+    GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN: (
+        "(x2^2 - L^2/12) normalized by its max absolute value; symmetric, "
+        "zero mean, with max absolute value 1"
+    ),
 }
 SOLVER_NAMES = ("fdm", "fem")
 
@@ -255,6 +266,15 @@ def run_case(
     write_figures: bool = True,
 ) -> None:
     case_dir = output_dir / run.name
+    write_run_readme(
+        case_dir,
+        run,
+        output_lines=(
+            "`residuals.csv`, `samples.csv`, `displacement.csv`, and "
+            "`parameters.csv` contain this solver's tabular artifacts.",
+            "PNG figures are written beside the CSV files when figures are enabled.",
+        ),
+    )
     run_case_to_dir(
         run,
         case_dir,
@@ -303,6 +323,51 @@ def run_case_to_dir(
         write_solution_figures(case_dir, run, solution)
 
     print(f"  wrote {case_dir}")
+
+
+def write_run_readme(
+    case_dir: Path,
+    run: SandwichRun,
+    output_lines: Sequence[str] | None = None,
+) -> None:
+    case_dir.mkdir(parents=True, exist_ok=True)
+    gradient = build_gradient_vector(run)
+    row_count = run.block_height * len(run.grad_factors)
+    full_thickness = (row_count - 1) * run.grid_step
+    layer_count = len(run.grad_factors)
+    if output_lines is None:
+        output_lines = (
+            "`fdm/` contains finite-difference CSV/PNG artifacts.",
+            "`fem/` contains finite-element CSV/PNG artifacts.",
+            "`comparison/` contains cross-solver comparison figures.",
+        )
+    readme = "\n".join(
+        [
+            f"# {run.name}",
+            "",
+            "## Scenario",
+            "",
+            f"- Layers: {layer_count}",
+            f"- Rows per layer: {run.block_height}",
+            f"- Columns: {run.block_width}",
+            f"- Grid step: {run.grid_step:g}",
+            f"- Full thickness: {full_thickness:g}",
+            f"- Gradient factors by layer: {run.grad_factors}",
+            "",
+            "## Boundary Load",
+            "",
+            f"- Profile: {run.gradient_profile}",
+            f"- Definition: {LOAD_DESCRIPTION_BY_GRADIENT_PROFILE[run.gradient_profile]}",
+            f"- Discrete min/max: {gradient.min():.12g} / {gradient.max():.12g}",
+            f"- Discrete max |load|: {np.max(np.abs(gradient)):.12g}",
+            "",
+            "## Outputs",
+            "",
+            *(f"- {line}" for line in output_lines),
+            "",
+        ]
+    )
+    (case_dir / "README.md").write_text(readme, encoding="utf-8")
 
 
 def report_progress(

--- a/sandwich_numerical/integration.py
+++ b/sandwich_numerical/integration.py
@@ -119,6 +119,7 @@ def build_gradient_vector(run: SandwichRun) -> np.ndarray:
         full_thickness = (height - 1) * run.grid_step
         x = np.linspace(-full_thickness / 2, full_thickness / 2, height)
         gradient = x**2 - full_thickness**2 / 12
+        gradient = gradient / np.max(np.abs(gradient))
     else:
         raise ValueError(f"Unsupported gradient profile: {run.gradient_profile}")
 

--- a/sandwich_numerical/integration.py
+++ b/sandwich_numerical/integration.py
@@ -118,8 +118,8 @@ def build_gradient_vector(run: SandwichRun) -> np.ndarray:
     elif run.gradient_profile == GRADIENT_PROFILE_PARABOLIC_ZERO_MEAN:
         full_thickness = (height - 1) * run.grid_step
         x = np.linspace(-full_thickness / 2, full_thickness / 2, height)
-        gradient = x**2 - full_thickness**2 / 12
-        gradient = gradient / np.max(np.abs(gradient))
+        # Symmetric zero-mean load with unit max amplitude for shape-only comparisons.
+        gradient = 6.0 * (x / full_thickness) ** 2 - 0.5
     else:
         raise ValueError(f"Unsupported gradient profile: {run.gradient_profile}")
 

--- a/scripts/run_sandwich_artifacts.py
+++ b/scripts/run_sandwich_artifacts.py
@@ -50,6 +50,7 @@ def main() -> None:
 
     for index, run in enumerate(runs, start=1):
         case_dir = output_dir / run.name
+        artifacts.write_run_readme(case_dir, run)
         for solver_name in solver_names:
             artifacts.run_case_to_dir(
                 run,

--- a/tests/fdm/test_sandwich_integration_e2e.py
+++ b/tests/fdm/test_sandwich_integration_e2e.py
@@ -63,15 +63,14 @@ def test_parabolic_zero_mean_gradient_profile_matches_formula() -> None:
     mesh_height = run.block_height * len(run.grad_factors)
     full_thickness = (mesh_height - 1) * run.grid_step
     x = np.linspace(-full_thickness / 2, full_thickness / 2, mesh_height)
-    expected = x**2 - full_thickness**2 / 12
-    expected = expected / np.max(np.abs(expected))
+    expected = 6.0 * (x / full_thickness) ** 2 - 0.5
 
     np.testing.assert_allclose(actual, expected, rtol=0, atol=1e-15)
     np.testing.assert_allclose(actual, actual[::-1], rtol=0, atol=1e-15)
     assert np.max(np.abs(actual)) == pytest.approx(1.0)
     analytic_integral = (
-        full_thickness**3 / 12 - full_thickness * full_thickness**2 / 12
-    ) / (full_thickness**2 / 6)
+        6.0 / full_thickness**2 * full_thickness**3 / 12 - full_thickness / 2
+    )
     assert analytic_integral == pytest.approx(0.0, abs=1e-15)
 
 

--- a/tests/fdm/test_sandwich_integration_e2e.py
+++ b/tests/fdm/test_sandwich_integration_e2e.py
@@ -64,12 +64,14 @@ def test_parabolic_zero_mean_gradient_profile_matches_formula() -> None:
     full_thickness = (mesh_height - 1) * run.grid_step
     x = np.linspace(-full_thickness / 2, full_thickness / 2, mesh_height)
     expected = x**2 - full_thickness**2 / 12
+    expected = expected / np.max(np.abs(expected))
 
     np.testing.assert_allclose(actual, expected, rtol=0, atol=1e-15)
     np.testing.assert_allclose(actual, actual[::-1], rtol=0, atol=1e-15)
+    assert np.max(np.abs(actual)) == pytest.approx(1.0)
     analytic_integral = (
         full_thickness**3 / 12 - full_thickness * full_thickness**2 / 12
-    )
+    ) / (full_thickness**2 / 6)
     assert analytic_integral == pytest.approx(0.0, abs=1e-15)
 
 

--- a/tests/test_sandwich_artifacts_pipeline.py
+++ b/tests/test_sandwich_artifacts_pipeline.py
@@ -112,6 +112,9 @@ def test_unified_cli_local_csv_smoke(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     case_dir = output_dir / "grad_factors_1_1_1_load_sin"
+    readme = case_dir / "README.md"
+    assert readme.exists()
+    assert "Layers: 3" in readme.read_text(encoding="utf-8")
     for solver_name in artifacts.SOLVER_NAMES:
         assert (case_dir / solver_name / "samples.csv").exists()
         assert (case_dir / solver_name / "displacement.csv").exists()


### PR DESCRIPTION
## Summary

- Use the analytic `parabolic_zero_mean` boundary-gradient profile `6*(x/L)^2 - 1/2`, where `x` is the centered thickness coordinate in `[-L/2, L/2]`.
- Document the configured sandwich integration scenarios and load profiles in the repository README.
- Generate short per-run artifact README files from the unified artifact pipeline, including layer count, gradient factors, load parameters, and output layout.

## Root Cause

The parabolic load was previously left in physical `x^2 - L^2/12` units, giving it a max absolute value much smaller than the sine profile for the configured thicknesses. Dividing that raw profile by its edge maximum `L^2/6` gives the analytic form `6*(x/L)^2 - 1/2`. This keeps the profile symmetric, zero-mean, and unit-amplitude so displacement differences reflect load shape rather than load scale or net boundary-gradient bias.

## Validation

- `.venv/bin/flake8 sandwich_numerical/integration.py sandwich_numerical/artifacts.py tests/fdm/test_sandwich_integration_e2e.py`
- `.venv/bin/black --check sandwich_numerical/integration.py`
- `.venv/bin/black --check sandwich_numerical/artifacts.py`
- `.venv/bin/black --check tests/fdm/test_sandwich_integration_e2e.py`
- `.venv/bin/python -m pytest tests/test_sandwich_artifacts_pipeline.py tests/fdm/test_sandwich_integration_e2e.py::test_parabolic_zero_mean_gradient_profile_matches_formula -q`
- `git diff --check`
- Regenerated local artifacts with `.venv/bin/python scripts/run_sandwich_artifacts.py --mode local --all-cases --output-dir artifacts/local_sandwich_integration`
- Refreshed local per-run README files under `artifacts/local_sandwich_integration` after the analytic-description update